### PR TITLE
first working version of PIO write in FMS1

### DIFF
--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -1438,3 +1438,8 @@ subroutine mpp_type_free(dtype)
         call increment_current_clock(EVENT_TYPE_FREE, MPP_TYPE_BYTELEN_)
 
 end subroutine mpp_type_free
+
+function get_mpp_comm()
+  integer :: get_mpp_comm
+  get_mpp_comm = mpp_comm_private
+end function get_mpp_comm

--- a/mpp/include/mpp_io_connect.inc
+++ b/mpp/include/mpp_io_connect.inc
@@ -206,6 +206,13 @@
       character(len=128)                    :: f_test
 
 !----------
+! PIO flag
+      logical :: pio_flag = .false.
+#ifdef use_PIO
+      pio_flag = .true.
+#endif
+
+!----------
 !ug support
      !Only allow one type of mpp domain.
       if (present(domain) .and. present(domain_ug)) then
@@ -291,6 +298,13 @@
 !----------
 
       endif
+
+      ! pio support
+      if(pio_flag .and. form_flag == MPP_NETCDF) then
+        write_on_this_pe = .true.
+        !read_on_this_pe = .true.
+      endif
+
       if( action_flag == MPP_RDONLY) write_on_this_pe = .false.
       !get a unit number
       if( .NOT. write_on_this_pe .AND. action_flag.NE.MPP_RDONLY .AND. .NOT. io_domain_exist)then
@@ -547,7 +561,33 @@
 #endif
 
 #ifdef use_netCDF
-#ifdef use_netCDF3
+#ifdef use_PIO
+          if( action_flag.EQ.MPP_WRONLY )then
+              if(debug) write(*,*) 'Blocksize for create of ', trim(mpp_file(unit)%name),' is ', fsize
+              error = mpp_pio_openfile(mpp_file(unit)%fileDesc, mpp_file(unit)%name, action_flag, mpp_file(unit)%ncid)
+              call netcdf_err( error, mpp_file(unit) )
+              if( verbose )print '(a,i6,i16)', 'MPP_OPEN: new netCDF file: pe, filename=', pe, mpp_file(unit)%name
+          else if( action_flag.EQ.MPP_OVERWR )then
+              if(debug) write(*,*) 'Blocksize for create of ', trim(mpp_file(unit)%name),' is ', fsize
+              error = mpp_pio_openfile(mpp_file(unit)%fileDesc, mpp_file(unit)%name, action_flag, mpp_file(unit)%ncid)
+              call netcdf_err( error, mpp_file(unit) )
+              action_flag = MPP_WRONLY !after setting clobber, there is no further distinction btwn MPP_WRONLY and MPP_OVERWR
+              if( verbose )print '(a,i6,i16)', 'MPP_OPEN: overwrite netCDF file: pe, filename=', pe, mpp_file(unit)%name
+          else if( action_flag.EQ.MPP_APPEND )then
+              print *, "debug ", __FILE__, __LINE__
+              call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+          else if( action_flag.EQ.MPP_RDONLY )then
+              inquire(file=trim(mpp_file(unit)%name),EXIST=exists)
+              if (.NOT.exists) call mpp_error(FATAL,'MPP_OPEN:'&
+                   &//trim(mpp_file(unit)%name)//' does not exist.')
+              error=NF__OPEN(trim(mpp_file(unit)%name),NF_NOWRITE,fsize,mpp_file(unit)%ncid);call netcdf_err(error,mpp_file(unit))
+              if( verbose )print '(a,i6,i16,i4)', 'MPP_OPEN: opening existing netCDF file: pe, ncid, time_axis_id=',&
+                   pe, mpp_file(unit)%ncid, mpp_file(unit)%id
+              mpp_file(unit)%format=form_flag ! need this for mpp_read
+              call mpp_read_meta(unit, read_time=.TRUE.)
+          end if
+          mpp_file(unit)%opened = .TRUE.
+#elif use_netCDF3
           if( action_flag.EQ.MPP_WRONLY )then
               if(debug) write(*,*) 'Blocksize for create of ', trim(mpp_file(unit)%name),' is ', fsize
               error = NF__CREATE( trim(mpp_file(unit)%name), NF_NOCLOBBER, inital, fsize, mpp_file(unit)%ncid )
@@ -808,7 +848,15 @@
       if( mpp_file(unit)%opened) then
          if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
 #ifdef use_netCDF
-            error = NF_CLOSE(mpp_file(unit)%ncid); call netcdf_err( error, mpp_file(unit) )
+#ifndef use_PIO
+      error = NF_CLOSE(mpp_file(unit)%ncid); call netcdf_err( error, mpp_file(unit) )
+#else
+      if( mpp_file(unit)%action == MPP_RDONLY )then
+          error = NF_CLOSE(mpp_file(unit)%ncid); call netcdf_err( error, mpp_file(unit) ) ! todo
+      else
+          call PIO_closefile(mpp_file(unit)%fileDesc)
+      endif
+#endif
 #endif
          else
             close(unit,status=status)

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -175,6 +175,10 @@
 #endif
       endif
 
+#ifdef use_PIO
+      call mpp_pio_init()
+#endif
+
       call mpp_io_set_stack_size(131072) ! default initial value
       call mpp_sync()
       if( io_clocks_on )then
@@ -224,7 +228,15 @@
 #ifdef use_netCDF
 !close all open netCDF units
       do unit = maxunits+1,2*maxunits
+#ifndef use_PIO
          if( mpp_file(unit)%opened )error = NF_CLOSE(mpp_file(unit)%ncid)
+#else
+         if( mpp_file(unit)%action == MPP_RDONLY) then
+            if( mpp_file(unit)%opened )error = NF_CLOSE(mpp_file(unit)%ncid)
+         else
+            if( mpp_file(unit)%opened )call PIO_closefile(mpp_file(unit)%fileDesc)
+         endif
+#endif
       end do
 #endif
 
@@ -275,7 +287,16 @@
 
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
 #ifdef use_netCDF
+#ifndef use_PIO
           error = NF_SYNC(mpp_file(unit)%ncid); call netcdf_err( error, mpp_file(unit) )
+#else
+         if( mpp_file(unit)%action == MPP_RDONLY) then
+            error = NF_SYNC(mpp_file(unit)%ncid); call netcdf_err( error, mpp_file(unit) )
+         else
+            call PIO_syncfile(mpp_file(unit)%fileDesc)
+            !if( mpp_file(unit)%opened )call PIO_closefile(mpp_file(unit)%fileDesc) ! TODO: is this needed?
+         endif
+#endif
 #endif
       else
           FLUSH(unit)

--- a/mpp/include/mpp_pio_write.inc
+++ b/mpp/include/mpp_pio_write.inc
@@ -1,0 +1,1811 @@
+! -*-f90-*-
+
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                            !
+!                             MPP_WRITE_META                                 !
+!                                                                            !
+!> @file
+!> @ingroup mpp_io_mod
+!> @brief This series of routines is used to describe the contents of the file
+!! being written on <unit>.
+!!
+!> Each file can contain any number of fields,
+!! which can be functions of 0-3 spatial axes and 0-1 time axes. Axis
+!! descriptors are stored in the <axistype> structure and field
+!! descriptors in the <fieldtype> structure.
+!!
+!! The metadata contained in the type is always written for each axis and
+!! field. Any other metadata one wishes to attach to an axis or field
+!! can subsequently be passed to mpp_write_meta using the ID, as shown below.
+!!
+!! mpp_write_meta can take several forms:
+!!
+!!  mpp_write_meta( unit, name, rval=rval, pack=pack )
+!!  mpp_write_meta( unit, name, ival=ival )
+!!  mpp_write_meta( unit, name, cval=cval )
+!!      integer, intent(in) :: unit
+!!      character(len=*), intent(in) :: name
+!!      real, intent(in), optional :: rval(:)
+!!      integer, intent(in), optional :: ival(:)
+!!      character(len=*), intent(in), optional :: cval
+!!
+!! This form defines global metadata associated with the file as a
+!! whole. The attribute is named <name> and can take on a real, integer
+!! or character value. <rval> and <ival> can be scalar or 1D arrays.
+!!
+!!  mpp_write_meta( unit, id, name, rval=rval, pack=pack )
+!!  mpp_write_meta( unit, id, name, ival=ival )
+!!  mpp_write_meta( unit, id, name, cval=cval )
+!!      integer, intent(in) :: unit, id
+!!      character(len=*), intent(in) :: name
+!!      real, intent(in), optional :: rval(:)
+!!      integer, intent(in), optional :: ival(:)
+!!      character(len=*), intent(in), optional :: cval
+!!
+!! This form defines metadata associated with a previously defined
+!! axis or field, identified to mpp_write_meta by its unique ID <id>.
+!! The attribute is named <name> and can take on a real, integer
+!! or character value. <rval> and <ival> can be scalar or 1D arrays.
+!! This need not be called for attributes already contained in
+!! the type.
+!!
+!! PACK can take values 1,2,4,8. This only has meaning when writing
+!! floating point numbers. The value of PACK defines the number of words
+!! written into 8 bytes. For pack=4 and pack=8, an integer value is
+!! written: rval is assumed to have been scaled to the appropriate dynamic
+!! range.
+!! PACK currently only works for netCDF files, and is ignored otherwise.
+!!
+!!  subroutine mpp_write_meta_axis( unit, axis, name, units, longname, &
+!!        cartesian, sense, domain, data )
+!!     integer, intent(in) :: unit
+!!     type(axistype), intent(inout) :: axis
+!!     character(len=*), intent(in) :: name, units, longname
+!!     character(len=*), intent(in), optional :: cartesian
+!!     integer, intent(in), optional :: sense
+!!     type(domain1D), intent(in), optional :: domain
+!!     real, intent(in), optional :: data(:)
+!!
+!! This form defines a time or space axis. Metadata corresponding to the
+!! type above are written to the file on <unit>. A unique ID for subsequent
+!! references to this axis is returned in axis%id. If the <domain>
+!! element is present, this is recognized as a distributed data axis
+!! and domain decomposition information is also written if required (the
+!! domain decomposition info is required for multi-fileset multi-threaded
+!! I/O). If the <datLINK> element is allocated, it is considered to be a
+!! space axis, otherwise it is a time axis with an unlimited dimension.
+!! Only one time axis is allowed per file.
+!! @code{.F90}
+!!  subroutine mpp_write_meta_field( unit, field, axes, name, units, longname 
+!!                                   standard_name, min, max, missing, fill, scale, add, pack)
+!!     integer, intent(in) :: unit
+!!     type(fieldtype), intent(out) :: field
+!!     type(axistype), intent(in) :: axes(:)
+!!     character(len=*), intent(in) :: name, units, longname, standard_name
+!!     real, intent(in), optional :: min, max, missing, fill, scale, add
+!!     integer, intent(in), optional :: pack
+!! @endcode
+!! This form defines a field. Metadata corresponding to the type
+!! above are written to the file on <unit>. A unique ID for subsequent
+!! references to this field is returned in field%id. At least one axis
+!! must be associated, 0D variables are not considered. mpp_write_meta
+!! must previously have been called on all axes associated with this
+!! field.
+!!
+!! The mpp_write_meta package also includes subroutines write_attribute and
+!! write_attribute_netcdf, that are private to this module.
+!                                                                            !
+!                                                                            !
+!  type, public :: axistype                                                  !
+!     sequence                                                               !
+!     character(len=128) :: name                                             !
+!     character(len=128) :: units                                            !
+!     character(len=256) :: longname                                         !
+!     integer :: sense           !+/-1, depth or height?                     !
+!     type(domain1D) :: domain                                               !
+!     real, pointer :: data(:) !axis values (not used if time axis)          !
+!     integer :: id                                                          !
+!  end type axistype                                                         !
+!                                                                            !
+!  type, public :: fieldtype                                                 !
+!     sequence                                                               !
+!     character(len=128) :: name                                             !
+!     character(len=128) :: units                                            !
+!     character(len=256) :: longname                                         !
+!     character(len=256) :: standard_name  !CF standard name                 !
+!     real :: min, max, missing, fill, scale, add                            !
+!     type(axistype), pointer :: axis(:)                                     !
+!     integer :: id                                                          !
+!  end type fieldtype                                                        !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!> Writes a global metadata attribute to unit <unit>
+!! attribute <name> can be an real, integer or character
+!! one and only one of rval, ival, and cval should be present
+!! the first found will be used
+!! for a non-netCDF file, it is encoded into a string "GLOBAL <name> <val>"
+    subroutine mpp_write_meta_global( unit, name, rval, ival, cval, pack)
+      integer, intent(in) :: unit
+      character(len=*), intent(in) :: name
+      real,             intent(in), optional :: rval(:)
+      integer,          intent(in), optional :: ival(:)
+      character(len=*), intent(in), optional :: cval
+      integer, intent(in), optional :: pack
+
+!      call mpp_clock_begin(mpp_write_clock)
+      if( .NOT.module_is_initialized    )call mpp_error( FATAL, 'MPP_WRITE_META: must first call mpp_io_init.' )
+      if( .NOT. mpp_file(unit)%write_on_this_pe) then
+!         call mpp_clock_end(mpp_write_clock)
+         return
+      endif
+      if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
+      if( mpp_file(unit)%initialized ) &
+           call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
+
+      if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
+#ifdef use_netCDF
+          call write_attribute_pio_global( unit, name, rval, ival, cval, pack )
+#endif
+      else
+          call write_attribute( unit, 'GLOBAL '//trim(name), rval, ival, cval, pack )
+      end if
+!      call mpp_clock_end(mpp_write_clock)
+
+      return
+    end subroutine mpp_write_meta_global
+
+!versions of above to support <rval> and <ival> as scalars (because of f90 strict rank matching)
+    subroutine mpp_write_meta_global_scalar_r( unit, name, rval, pack )
+      integer, intent(in) :: unit
+      character(len=*), intent(in) :: name
+      real, intent(in) :: rval
+      integer, intent(in), optional :: pack
+
+      call mpp_write_meta_global( unit, name, rval=(/rval/), pack=pack )
+      return
+    end subroutine mpp_write_meta_global_scalar_r
+
+    subroutine mpp_write_meta_global_scalar_i( unit, name, ival, pack )
+      integer, intent(in) :: unit
+      character(len=*), intent(in) :: name
+      integer, intent(in) :: ival
+      integer, intent(in), optional :: pack
+
+      call mpp_write_meta_global( unit, name, ival=(/ival/), pack=pack )
+      return
+    end subroutine mpp_write_meta_global_scalar_i
+
+    subroutine mpp_write_meta_var( unit, id, name, rval, ival, cval, pack)
+!writes a metadata attribute for variable <id> to unit <unit>
+!attribute <name> can be an real, integer or character
+!one and only one of rval, ival, and cval should be present
+!the first found will be used
+!for a non-netCDF file, it is encoded into a string "<id> <name> <val>"
+      integer, intent(in) :: unit, id
+      character(len=*), intent(in) :: name
+      real,             intent(in), optional :: rval(:)
+      integer,          intent(in), optional :: ival(:)
+      character(len=*), intent(in), optional :: cval
+      integer,          intent(in), optional :: pack
+
+      if( .NOT.module_is_initialized    )call mpp_error( FATAL, 'MPP_WRITE_META: must first call mpp_io_init.' )
+      if( .NOT. mpp_file(unit)%write_on_this_pe) then
+         return
+      endif
+      if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
+      if( mpp_file(unit)%initialized ) &
+           call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
+
+      if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
+          call write_attribute_pio( unit, id, name, rval, ival, cval, pack )
+      else
+          write( text, '(a,i4,a)' )'VARIABLE ', id, ' '//name
+          call write_attribute( unit, trim(text), rval, ival, cval, pack )
+      end if
+
+      return
+    end subroutine mpp_write_meta_var
+
+!versions of above to support <rval> and <ival> as scalar (because of f90 strict rank matching)
+    subroutine mpp_write_meta_scalar_r( unit, id, name, rval, pack )
+      integer, intent(in) :: unit, id
+      character(len=*), intent(in) :: name
+      real, intent(in) :: rval
+      integer, intent(in), optional :: pack
+
+      call mpp_write_meta( unit, id, name, rval=(/rval/), pack=pack )
+      return
+    end subroutine mpp_write_meta_scalar_r
+
+    subroutine mpp_write_meta_scalar_i( unit, id, name, ival,pack )
+      integer, intent(in) :: unit, id
+      character(len=*), intent(in) :: name
+      integer, intent(in) :: ival
+      integer, intent(in), optional :: pack
+
+      call mpp_write_meta( unit, id, name, ival=(/ival/),pack=pack )
+      return
+    end subroutine mpp_write_meta_scalar_i
+
+
+    subroutine mpp_write_axis_data (unit, axes )
+      integer, intent(in) :: unit
+      type(axistype), dimension(:), intent(in) :: axes
+
+      integer :: naxis
+#ifndef use_PIO
+      naxis = size (axes)
+      allocate (mpp_file(unit)%axis(naxis))
+      mpp_file(unit)%axis(1:naxis) = axes(1:naxis)
+#ifdef use_netCDF
+      if( mpp_file(unit)%action.EQ.MPP_WRONLY )then
+         if(header_buffer_val>0) then
+            error = NF__ENDDEF(mpp_file(unit)%ncid,header_buffer_val,4,0,4)
+         else
+            error = NF_ENDDEF(mpp_file(unit)%ncid)
+         endif
+      endif
+#endif
+#else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+#endif
+    end subroutine mpp_write_axis_data
+
+    subroutine mpp_def_dim_nodata(unit,name,size)
+      integer, intent(in) :: unit
+      character(len=*), intent(in) :: name
+      integer, intent(in) :: size
+      integer :: error,did
+
+#ifndef use_PIO
+    ! This routine assumes the file is in define mode
+      if(.NOT. mpp_file(unit)%write_on_this_pe) return
+#ifdef use_netCDF
+      error = NF_DEF_DIM(mpp_file(unit)%ncid,name,size,did)
+      call netcdf_err(error, mpp_file(unit),string='Axis='//trim(name))
+#endif
+#else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+#endif
+    end subroutine mpp_def_dim_nodata
+
+    subroutine mpp_def_dim_int(unit,name,dsize,longname,data)
+      integer, intent(in) :: unit
+      character(len=*), intent(in) :: name
+      integer, intent(in) :: dsize
+      character(len=*), intent(in) :: longname
+      integer, intent(in) :: data(:)
+      integer :: error,did,id
+
+#ifndef use_PIO
+    ! This routine assumes the file is in define mode
+#ifdef use_netCDF
+      if(.NOT. mpp_file(unit)%write_on_this_pe) return
+      error = NF_DEF_DIM(mpp_file(unit)%ncid,name,dsize,did)
+      call netcdf_err(error, mpp_file(unit),string='Axis='//trim(name))
+
+    ! Write dimension data.
+      error = NF_DEF_VAR( mpp_file(unit)%ncid, name, NF_INT, 1, (/did/), id )
+      call netcdf_err( error, mpp_file(unit), string=' axis varable '//trim(name))
+
+      error = NF_PUT_ATT_TEXT( mpp_file(unit)%ncid, id, 'long_name', len_trim(longname), longname )
+      call netcdf_err( error, mpp_file(unit), string=' Attribute=long_name' )
+
+      if( mpp_file(unit)%action.EQ.MPP_WRONLY )then
+         if(header_buffer_val>0) then
+            error = NF__ENDDEF(mpp_file(unit)%ncid,header_buffer_val,4,0,4)
+         else
+            error = NF_ENDDEF(mpp_file(unit)%ncid)
+         endif
+      endif
+      call netcdf_err( error, mpp_file(unit), string=' subroutine mpp_def_dim')
+      error = NF_PUT_VARA_INT ( mpp_file(unit)%ncid, id, (/1/), (/size(data)/), data )
+      call netcdf_err( error, mpp_file(unit), string=' axis varable '//trim(name))
+      error = NF_REDEF(mpp_file(unit)%ncid)
+      call netcdf_err( error, mpp_file(unit), string=' subroutine mpp_def_dim')
+#endif
+#else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+#endif
+    return
+  end subroutine mpp_def_dim_int
+
+    subroutine mpp_def_dim_real(unit,name,dsize,longname,data)
+      integer, intent(in) :: unit
+      character(len=*), intent(in) :: name
+      integer, intent(in) :: dsize
+      character(len=*), intent(in) :: longname
+      real, intent(in) :: data(:)
+      integer :: error,did,id
+
+    ! This routine assumes the file is in define mode
+#ifndef use_PIO
+#ifdef use_netCDF
+      if(.NOT. mpp_file(unit)%write_on_this_pe) return
+      error = NF_DEF_DIM(mpp_file(unit)%ncid,name,dsize,did)
+      call netcdf_err(error, mpp_file(unit),string='Axis='//trim(name))
+
+    ! Write dimension data.
+      error = NF_DEF_VAR( mpp_file(unit)%ncid, name, NF_INT, 1, (/did/), id )
+      call netcdf_err( error, mpp_file(unit), string=' axis varable '//trim(name))
+
+      error = NF_PUT_ATT_TEXT( mpp_file(unit)%ncid, id, 'long_name', len_trim(longname), longname )
+      call netcdf_err( error, mpp_file(unit), string=' Attribute=long_name' )
+
+      if( mpp_file(unit)%action.EQ.MPP_WRONLY )then
+         if(header_buffer_val>0) then
+            error = NF__ENDDEF(mpp_file(unit)%ncid,header_buffer_val,4,0,4)
+         else
+            error = NF_ENDDEF(mpp_file(unit)%ncid)
+         endif
+      endif
+      call netcdf_err( error, mpp_file(unit), string=' subroutine mpp_def_dim')
+      error = NF90_PUT_VAR ( mpp_file(unit)%ncid, id, data, start=(/1/), count=(/size(data)/) )
+      call netcdf_err( error, mpp_file(unit), string=' axis varable '//trim(name))
+      error = NF_REDEF(mpp_file(unit)%ncid)
+      call netcdf_err( error, mpp_file(unit), string=' subroutine mpp_def_dim')
+#endif
+#else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+#endif
+    return
+  end subroutine mpp_def_dim_real
+
+
+
+    subroutine mpp_write_meta_axis_r1d( unit, axis, name, units, longname, cartesian, sense, domain, data, min, calendar)
+!load the values in an axistype (still need to call mpp_write)
+!write metadata attributes for axis
+!it is declared intent(inout) so you can nullify pointers in the incoming object if needed
+!the f90 standard doesn't guarantee that intent(out) on a type guarantees that its pointer components will be unassociated
+      integer,          intent(in)           :: unit
+      type(axistype),   intent(inout)        :: axis
+      character(len=*), intent(in)           :: name, units, longname
+      character(len=*), intent(in), optional :: cartesian
+      integer,          intent(in), optional :: sense
+      type(domain1D),   intent(in), optional :: domain
+      real,             intent(in), optional :: data(:)
+      real,             intent(in), optional :: min
+      character(len=*), intent(in), optional :: calendar
+
+      integer :: is, ie, isg, ieg
+      integer :: istat
+      logical :: domain_exist
+      type(domain2d), pointer :: io_domain => NULL()
+
+!      call mpp_clock_begin(mpp_write_clock)
+      !--- the shift and cartesian information is needed in mpp_write_meta_field from all the pe.
+      !--- we may revise this in the future.
+      axis%cartesian = 'N'
+      if( PRESENT(cartesian) )axis%cartesian = cartesian
+
+      domain_exist = .false.
+
+     if( PRESENT(domain) ) then
+         domain_exist = .true.
+         call mpp_get_global_domain( domain, isg, ieg )
+         if(mpp_file(unit)%io_domain_exist) then
+            io_domain => mpp_get_io_domain(mpp_file(unit)%domain)
+            if(axis%cartesian=='X') then
+               call mpp_get_global_domain( io_domain, xbegin=is, xend=ie)
+            else if(axis%cartesian=='Y') then
+               call mpp_get_global_domain( io_domain, ybegin=is, yend=ie)
+            endif
+         else
+            call mpp_get_compute_domain( domain, is, ie )
+         endif
+      else if( PRESENT(data) )then
+         isg=1; ieg=size(data(:)); is=isg; ie=ieg
+      endif
+
+      axis%shift = 0
+      if( PRESENT(data) .AND. domain_exist ) then
+         if( size(data(:)) == ieg-isg+2 ) then
+            axis%shift = 1
+            ie = ie   + 1
+            ieg = ieg + 1
+         endif
+      endif
+
+      if( .NOT.module_is_initialized    )call mpp_error( FATAL, 'MPP_WRITE_META: must first call mpp_io_init.' )
+      if( .NOT. mpp_file(unit)%write_on_this_pe) then
+!         call mpp_clock_end(mpp_write_clock)
+         return
+      endif
+      if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
+      if( mpp_file(unit)%initialized ) &
+           call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
+
+!pre-existing pointers need to be nullified
+      if( ASSOCIATED(axis%data) ) then
+         DEALLOCATE(axis%data, stat=istat)
+      endif
+!load axistype
+      axis%name     = name
+      axis%units    = units
+      axis%longname = longname
+      if( PRESENT(calendar)  ) axis%calendar  = calendar
+      if( PRESENT(sense)     ) axis%sense     = sense
+      if( PRESENT(data) )then
+         if( mpp_file(unit)%fileset.EQ.MPP_MULTI .AND. domain_exist ) then
+            axis%len = ie - is + 1
+            allocate(axis%data(axis%len))
+            axis%data = data(is-isg+1:ie-isg+1)
+         else
+            axis%len = size(data(:))
+            allocate(axis%data(axis%len))
+            axis%data = data
+         endif
+      endif
+!write metadata
+      if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
+#ifdef use_netCDF
+!write axis def
+!space axes are always floats, time axis is always double
+          if( ASSOCIATED(axis%data) )then !space axis
+              error = PIO_def_dim( mpp_file(unit)%ncid, axis%name, axis%len, axis%did)
+              call netcdf_err( error, mpp_file(unit), axis )
+              if(pack_size == 1) then
+                 error = PIO_def_var( mpp_file(unit)%ncid, axis%name, PIO_DOUBLE, (/axis%did/), axis%id)
+              else ! pack_size == 2
+                 error = PIO_def_var( mpp_file(unit)%ncid, axis%name, PIO_REAL, (/axis%did/), axis%id)
+              endif
+              call netcdf_err( error, mpp_file(unit), axis )
+          else                            !time axis
+              if( mpp_file(unit)%id.NE.-1 ) &
+                   call mpp_error( FATAL, 'MPP_WRITE_META_AXIS: There is already a time axis for this file.' )
+              error = PIO_def_dim( mpp_file(unit)%ncid, axis%name, PIO_UNLIMITED, axis%did)
+              call netcdf_err( error, mpp_file(unit), axis )
+              if(pack_size == 1) then
+                 error = PIO_def_var( mpp_file(unit)%ncid, axis%name, PIO_DOUBLE, (/axis%did/), axis%id)
+              else ! pack_size == 2
+                 error = PIO_def_var( mpp_file(unit)%ncid, axis%name, PIO_REAL, (/axis%did/), axis%id)
+              endif
+              call netcdf_err( error, mpp_file(unit), axis )
+              mpp_file(unit)%id = axis%id !file ID is the same as time axis varID
+          end if
+#endif
+      else
+          varnum = varnum + 1
+          axis%id = varnum
+          axis%did = varnum
+!write axis def
+          write( text, '(a,i4,a)' )'AXIS ', axis%id, ' name'
+          call write_attribute( unit, trim(text), cval=axis%name )
+          write( text, '(a,i4,a)' )'AXIS ', axis%id, ' size'
+          if( ASSOCIATED(axis%data) )then !space axis
+!              if( mpp_file(unit)%fileset.EQ.MPP_MULTI .AND. axis%domain.NE.NULL_DOMAIN1D )then
+!                  call write_attribute( unit, trim(text), ival=(/ie-is+1/) )
+!              else
+                  call write_attribute( unit, trim(text), ival=(/size(axis%data(:))/) )
+!              end if
+          else                            !time axis
+              if( mpp_file(unit)%id.NE.-1 ) &
+                   call mpp_error( FATAL, 'MPP_WRITE_META_AXIS: There is already a time axis for this file.' )
+              call write_attribute( unit, trim(text), ival=(/0/) ) !a size of 0 indicates time axis
+              mpp_file(unit)%id = axis%id
+          end if
+      end if
+!write axis attributes
+      call mpp_write_meta( unit, axis%id, 'long_name', cval=axis%longname) ; axis%natt = axis%natt + 1
+      if (lowercase(trim(axis%units)).ne.'none' .OR. .NOT.cf_compliance) then
+        call mpp_write_meta( unit, axis%id, 'units',     cval=axis%units) ; axis%natt = axis%natt + 1
+      endif
+      if( PRESENT(calendar) ) then
+        if (.NOT.cf_compliance) then
+          call mpp_write_meta( unit, axis%id, 'calendar', cval=axis%calendar)
+        else
+          call mpp_write_meta( unit, axis%id, 'calendar', cval=lowercase(axis%calendar))
+        endif
+        axis%natt = axis%natt + 1
+      endif
+      if( PRESENT(cartesian) ) then
+        if (.NOT.cf_compliance) then
+          call mpp_write_meta( unit, axis%id, 'cartesian_axis', cval=axis%cartesian)
+          axis%natt = axis%natt + 1
+        else
+          if (trim(axis%cartesian).ne.'N') then
+            call mpp_write_meta( unit, axis%id, 'axis', cval=axis%cartesian)
+            axis%natt = axis%natt + 1
+          endif
+        endif
+      endif
+      if( PRESENT(sense) )then
+          if( sense.EQ.-1 )then
+              call mpp_write_meta( unit, axis%id, 'positive', cval='down')
+              axis%natt = axis%natt + 1
+          else if( sense.EQ.1 )then
+              call mpp_write_meta( unit, axis%id, 'positive', cval='up')
+              axis%natt = axis%natt + 1
+          else
+             ! silently ignore values of sense other than +/-1.
+          end if
+      end if
+      if( PRESENT(min) ) then
+        call mpp_write_meta( unit, axis%id, 'valid_min', rval=min)
+        axis%natt = axis%natt + 1
+      endif
+      if( mpp_file(unit)%threading.EQ.MPP_MULTI .AND. mpp_file(unit)%fileset.EQ.MPP_MULTI .AND. domain_exist )then
+          call mpp_write_meta( unit, axis%id, 'domain_decomposition', ival=(/isg,ieg,is,ie/))
+          axis%natt = axis%natt + 1
+      end if
+      if( verbose )print '(a,2i6,x,a,2i3)', 'MPP_WRITE_META: Wrote axis metadata, pe, unit, axis%name, axis%id, axis%did=', &
+           pe, unit, trim(axis%name), axis%id, axis%did
+
+      mpp_file(unit)%ndim = max(1,mpp_file(unit)%ndim + 1)
+
+!      call mpp_clock_end(mpp_write_clock)
+      return
+    end subroutine mpp_write_meta_axis_r1d
+
+    subroutine mpp_write_meta_axis_i1d(unit, axis, name, units, longname, data, min, compressed)
+!load the values in an axistype (still need to call mpp_write)
+!write metadata attributes for axis
+!it is declared intent(inout) so you can nullify pointers in the incoming object if needed
+!the f90 standard doesn't guarantee that intent(out) on a type guarantees that its pointer components will be unassociated
+      integer,          intent(in)           :: unit
+      type(axistype),   intent(inout)        :: axis
+      character(len=*), intent(in)           :: name, units, longname
+      integer,          intent(in)           :: data(:)
+      integer,          intent(in), optional :: min
+      character(len=*), intent(in), optional :: compressed
+
+      integer :: istat
+      logical :: domain_exist
+      type(domain2d), pointer :: io_domain => NULL()
+
+#ifndef use_PIO
+!      call mpp_clock_begin(mpp_write_clock)
+      if( .NOT.module_is_initialized    )call mpp_error( FATAL, 'MPP_WRITE_META_I1D: must first call mpp_io_init.' )
+      if( .NOT. mpp_file(unit)%write_on_this_pe) then
+!         call mpp_clock_end(mpp_write_clock)
+         return
+      endif
+      if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
+      if( mpp_file(unit)%initialized ) &
+           call mpp_error( FATAL, 'MPP_WRITE_META_I1D: cannot write metadata to file after an mpp_write.' )
+
+!pre-existing pointers need to be nullified
+      if( ASSOCIATED(axis%idata) ) then
+         DEALLOCATE(axis%idata, stat=istat)
+      endif
+!load axistype
+      axis%name     = name
+      axis%units    = units
+      axis%longname = longname
+      if( PRESENT(compressed)) axis%compressed = trim(compressed)
+      axis%len = size(data(:))
+      allocate(axis%idata(axis%len))
+       axis%idata = data
+!write metadata
+#ifdef use_netCDF
+      if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
+          error = NF_DEF_DIM( mpp_file(unit)%ncid, axis%name, axis%len, axis%did )
+          call netcdf_err( error, mpp_file(unit), axis )
+          error = NF_DEF_VAR( mpp_file(unit)%ncid, axis%name, NF_INT, 1, (/axis%did/), axis%id )
+          call netcdf_err( error, mpp_file(unit), axis )
+      else
+          call mpp_error( FATAL, 'MPP_WRITE_META_AXIS_I1D: Only netCDF format is currently supported.' )
+      end if
+#endif
+!write axis attributes
+      call mpp_write_meta( unit, axis%id, 'long_name', cval=axis%longname) ; axis%natt = axis%natt + 1
+      if (lowercase(trim(axis%units)).ne.'none' .OR. .NOT.cf_compliance) then
+        call mpp_write_meta( unit, axis%id, 'units',     cval=axis%units) ; axis%natt = axis%natt + 1
+      endif
+      if( PRESENT(compressed) ) then
+        call mpp_write_meta( unit, axis%id, 'compress', cval=axis%compressed)
+        axis%natt = axis%natt + 1
+      endif
+      if( PRESENT(min) ) then
+        call mpp_write_meta( unit, axis%id, 'valid_min', ival=min)
+        axis%natt = axis%natt + 1
+      endif
+      if( verbose )print '(a,2i6,x,a,2i3)', 'MPP_WRITE_META: Wrote axis metadata, pe, unit, axis%name, axis%id, axis%did=', &
+           pe, unit, trim(axis%name), axis%id, axis%did
+
+      mpp_file(unit)%ndim = max(1,mpp_file(unit)%ndim + 1)
+
+!      call mpp_clock_end(mpp_write_clock)
+      return
+#else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+#endif
+    end subroutine mpp_write_meta_axis_i1d
+
+
+    subroutine mpp_write_meta_axis_unlimited(unit, axis, name, data, unlimited, units, longname)
+!load the values in an axistype (still need to call mpp_write)
+!write metadata attributes for axis
+!it is declared intent(inout) so you can nullify pointers in the incoming object if needed
+!the f90 standard doesn't guarantee that intent(out) on a type guarantees that its pointer components will be unassociated
+      integer,          intent(in)           :: unit
+      type(axistype),   intent(inout)        :: axis
+      character(len=*), intent(in)           :: name
+      integer,          intent(in)           :: data  ! Number of elements to be written
+      logical,          intent(in)           :: unlimited  ! Provides unique arg signature
+      character(len=*), intent(in), optional :: units, longname
+
+      integer :: istat
+      logical :: domain_exist
+      type(domain2d), pointer :: io_domain => NULL()
+
+#ifndef use_PIO
+!      call mpp_clock_begin(mpp_write_clock)
+      if( .NOT.module_is_initialized    )call mpp_error( FATAL, 'MPP_WRITE_META_I1D: must first call mpp_io_init.' )
+      if( .NOT. mpp_file(unit)%write_on_this_pe) then
+!         call mpp_clock_end(mpp_write_clock)
+         return
+      endif
+      if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
+      if( mpp_file(unit)%initialized ) &
+           call mpp_error( FATAL, 'MPP_WRITE_META_I1D: cannot write metadata to file after an mpp_write.' )
+
+!load axistype
+      axis%name     = name
+      if(present(units)) axis%units    = units
+      if(present(longname)) axis%longname = longname
+      axis%len = 1
+      allocate(axis%idata(1))
+      axis%idata = data
+!write metadata
+#ifdef use_netCDF
+      if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
+          error = NF_DEF_DIM( mpp_file(unit)%ncid, axis%name, NF_UNLIMITED, axis%did )
+          call netcdf_err( error, mpp_file(unit), axis )
+          error = NF_DEF_VAR( mpp_file(unit)%ncid, axis%name, NF_INT, 0, (/axis%did/), axis%id )
+          call netcdf_err( error, mpp_file(unit), axis )
+      else
+          call mpp_error( FATAL, 'MPP_WRITE_META_AXIS_UNLIMITED: Only netCDF format is currently supported.' )
+      end if
+#endif
+!write axis attributes
+      if(present(longname)) then
+         call mpp_write_meta(unit,axis%id,'long_name',cval=axis%longname); axis%natt=axis%natt+1
+      endif
+      if(present(units)) then
+         if (lowercase(trim(axis%units)).ne.'none' .OR. .NOT.cf_compliance) then
+           call mpp_write_meta(unit,axis%id,'units',     cval=axis%units); axis%natt=axis%natt+1
+         endif
+      endif
+      if( verbose )print '(a,2i6,x,a,2i3)', &
+          'MPP_WRITE_META_UNLIMITED: Wrote axis metadata, pe, unit, axis%name, axis%id, axis%did=', &
+           pe, unit, trim(axis%name), axis%id, axis%did
+
+      mpp_file(unit)%ndim = max(1,mpp_file(unit)%ndim + 1)
+
+!      call mpp_clock_end(mpp_write_clock)
+      return
+#else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+#endif
+    end subroutine mpp_write_meta_axis_unlimited
+
+
+    subroutine mpp_write_meta_field( unit, field, axes, name, units, longname,&
+         min, max, missing, fill, scale, add, pack, time_method, standard_name, checksum)
+!define field: must have already called mpp_write_meta(axis) for each axis
+      integer, intent(in) :: unit
+      type(fieldtype), intent(inout) :: field
+      type(axistype), intent(in) :: axes(:)
+      character(len=*), intent(in) :: name, units, longname
+      real, intent(in), optional :: min, max, missing, fill, scale, add
+      integer, intent(in), optional :: pack
+      character(len=*), intent(in), optional :: time_method
+      character(len=*), intent(in), optional :: standard_name
+      integer(i8_kind), dimension(:), intent(in), optional :: checksum
+!this array is required because of f77 binding on netCDF interface
+      integer, allocatable :: axis_id(:)
+      real :: a, b
+      integer :: i, istat, ishift, jshift
+      character(len=64) :: checksum_char
+
+!      call mpp_clock_begin(mpp_write_clock)
+
+      !--- figure out the location of data, this is needed in mpp_write.
+      !--- for NON-symmetry domain, the position is not an issue.
+      !--- we may need to rethink how to address the symmetric issue.
+      ishift = 0; jshift = 0
+      do i = 1, size(axes(:))
+         select case ( lowercase( axes(i)%cartesian ) )
+         case ( 'x' )
+            ishift = axes(i)%shift
+         case ( 'y' )
+            jshift = axes(i)%shift
+         end select
+      end do
+
+      field%position = CENTER
+      if(ishift == 1 .AND. jshift == 1) then
+         field%position = CORNER
+      else if(ishift == 1) then
+         field%position = EAST
+      else if(jshift == 1) then
+         field%position = NORTH
+      endif
+
+      if( .NOT.module_is_initialized    )call mpp_error( FATAL, 'MPP_WRITE_META: must first call mpp_io_init.' )
+
+      if( .NOT.mpp_file(unit)%write_on_this_pe) then
+         if( .NOT. ASSOCIATED(field%axes) )allocate(field%axes(1)) !temporary fix
+!         call mpp_clock_end(mpp_write_clock)
+         return
+      endif
+      if( .NOT.mpp_file(unit)%opened ) call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
+      if( mpp_file(unit)%initialized )  then
+!     File has already been written to and needs to be returned to define mode.
+#ifdef use_netCDF
+        error = PIO_redef(mpp_file(unit)%ncid)
+#endif
+        mpp_file(unit)%initialized = .false.
+      endif
+!           call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
+
+!pre-existing pointers need to be nullified
+      if( ASSOCIATED(field%axes) ) DEALLOCATE(field%axes, stat=istat)
+      if( ASSOCIATED(field%size) ) DEALLOCATE(field%size, stat=istat)
+!fill in field metadata
+      field%name = name
+      field%units = units
+      field%longname = longname
+      allocate( field%axes(size(axes(:))) )
+      field%axes = axes
+      field%ndim = size(axes(:))
+      field%time_axis_index = -1 !this value will never match any axis index
+!size is buffer area for the corresponding axis info: it is required to buffer this info in the fieldtype
+!because axis might be reused in different files
+      allocate( field%size(size(axes(:))) )
+      do i = 1,size(axes(:))
+         if( ASSOCIATED(axes(i)%data) )then !space axis
+             field%size(i) = size(axes(i)%data(:))
+         else               !time
+             field%size(i) = 1
+             field%time_axis_index = i
+         end if
+      end do
+!attributes
+      if( PRESENT(min) )          field%min           = min
+      if( PRESENT(max) )          field%max           = max
+      if( PRESENT(scale) )        field%scale         = scale
+      if( PRESENT(add) )          field%add           = add
+      if( PRESENT(standard_name)) field%standard_name = standard_name
+      if( PRESENT(missing) )      field%missing       = missing
+      if( PRESENT(fill) )         field%fill          = fill
+      field%checksum      = 0
+      if( PRESENT(checksum) )     field%checksum(1:size(checksum)) = checksum(:)
+
+      ! Issue warning if fill and missing are different
+      if (present(fill).and.present(missing)) then
+          if (field%missing .ne. field%fill) then
+              call mpp_error(WARNING, 'MPP_WRITE_META: NetCDF attributes &
+                      &_FillValue and missing_value should be equal.')
+          end if
+      end if
+!pack is currently used only for netCDF
+      field%pack = 2        !default write 32-bit floats
+      if( PRESENT(pack) )field%pack = pack
+      if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
+#ifdef use_netCDF
+          allocate( axis_id(size(field%axes(:))) )
+          do i = 1,size(field%axes(:))
+             axis_id(i) = field%axes(i)%did
+          end do
+!write field def
+          select case (field%pack)
+              case(0)
+                  error = PIO_def_var( mpp_file(unit)%ncid, field%name, PIO_INT, axis_id, field%id)
+              case(1)
+                  error = PIO_def_var( mpp_file(unit)%ncid, field%name, PIO_DOUBLE, axis_id, field%id)
+              case(2)
+                  error = PIO_def_var( mpp_file(unit)%ncid, field%name, PIO_REAL, axis_id, field%id)
+              case default
+                  call mpp_error( FATAL, 'MPP_WRITE_META_FIELD: only legal packing values for PIO are 1,2.' )
+          end select
+          call netcdf_err( error, mpp_file(unit), field=field )
+          deallocate(axis_id)
+#ifndef use_netCDF3
+          if(shuffle .NE. 0 .OR. deflate .NE. 0) then
+             error = PIO_def_var_deflate( mpp_file(unit)%fileDesc, field%id, shuffle, deflate, deflate_level)
+             call netcdf_err( error, mpp_file(unit), field=field )
+          endif
+#endif
+#endif
+      else
+          varnum = varnum + 1
+          field%id = varnum
+          if( PRESENT(pack) )call mpp_error( WARNING, 'MPP_WRITE_META: Packing is currently available only on netCDF files.' )
+!write field def
+          write( text, '(a,i4,a)' )'FIELD ', field%id, ' name'
+          call write_attribute( unit, trim(text), cval=field%name )
+          write( text, '(a,i4,a)' )'FIELD ', field%id, ' axes'
+          call write_attribute( unit, trim(text), ival=field%axes(:)%did )
+      end if
+!write field attributes: these names follow netCDF conventions
+      call mpp_write_meta( unit, field%id, 'long_name', cval=field%longname)
+      if (lowercase(trim(field%units)).ne.'none' .OR. .NOT.cf_compliance) then
+        call mpp_write_meta( unit, field%id, 'units',     cval=field%units)
+      endif
+!all real attributes must be written as packed
+      if( PRESENT(min) .AND. PRESENT(max) )then
+          if( field%pack.EQ.1 .OR. field%pack.EQ.2 )then
+              call mpp_write_meta( unit, field%id, 'valid_range', rval=(/min,max/), pack=pack )
+          else
+              a = nint((min-add)/scale)
+              b = nint((max-add)/scale)
+              call mpp_write_meta( unit, field%id, 'valid_range', rval=(/a,  b  /), pack=pack )
+          end if
+      else if( PRESENT(min) )then
+          if( field%pack.EQ.1 .OR. field%pack.EQ.2 )then
+              call mpp_write_meta( unit, field%id, 'valid_min', rval=field%min, pack=pack )
+          else
+              a = nint((min-add)/scale)
+              call mpp_write_meta( unit, field%id, 'valid_min', rval=a, pack=pack )
+          end if
+      else if( PRESENT(max) )then
+          if( field%pack.EQ.1 .OR. field%pack.EQ.2 )then
+              call mpp_write_meta( unit, field%id, 'valid_max', rval=field%max, pack=pack )
+          else
+              a = nint((max-add)/scale)
+              call mpp_write_meta( unit, field%id, 'valid_max', rval=a, pack=pack )
+          end if
+      end if
+! write missing_value
+      if ( present(missing) ) then
+         if( field%pack.EQ.1 .OR. field%pack.EQ.2 )then
+            call mpp_write_meta( unit, field%id, 'missing_value', rval=field%missing, pack=pack )
+         else
+            a = nint((missing-add)/scale)
+            call mpp_write_meta( unit, field%id, 'missing_value', rval=a, pack=pack )
+         end if
+      end if
+! write _FillValue
+      if ( present(fill) ) then
+         if( field%pack.EQ.1 .OR. field%pack.EQ.2 )then
+            call mpp_write_meta( unit, field%id, '_FillValue', rval=field%fill, pack=pack )
+         else if (field%pack==0) then ! some safety checks for integer fills
+            if ( present(scale).OR.present(add) ) then
+               call mpp_error(FATAL,"add,scale not currently implimented for pack=0 int handling, try reals instead.")
+            else
+               ! Trust No One
+               call mpp_write_meta( unit, field%id, '_FillValue', ival=MPP_FILL_INT, pack=pack )
+            end if
+         else
+            a = nint((fill-add)/scale)
+            call mpp_write_meta( unit, field%id, '_FillValue', rval=a, pack=pack )
+         end if
+      end if
+
+      if( field%pack.NE.1 .AND. field%pack.NE.2 )then
+          call mpp_write_meta( unit, field%id, 'packing', ival=field%pack )
+          if( PRESENT(scale) )call mpp_write_meta( unit, field%id, 'scale_factor',  rval=field%scale )
+          if( PRESENT(add)   )call mpp_write_meta( unit, field%id, 'add_offset',    rval=field%add   )
+      end if
+
+      if( present(checksum) )then
+          write (checksum_char,'(Z16)') field%checksum(1)
+          do i = 2,size(checksum)
+            write (checksum_char,'(a,Z16)') trim(checksum_char)//",",checksum(i)
+          enddo
+          call mpp_write_meta( unit, field%id, 'checksum', cval=checksum_char )
+      end if
+
+      if ( PRESENT(time_method) ) then
+          call mpp_write_meta(unit,field%id, 'cell_methods',cval='time: '//trim(time_method))
+      endif
+      if ( PRESENT(standard_name)) &
+           call mpp_write_meta(unit,field%id,'standard_name ', cval=field%standard_name)
+
+      if( verbose )print '(a,2i6,x,a,i3)', 'MPP_WRITE_META: Wrote field metadata: pe, unit, field%name, field%id=', &
+           pe, unit, trim(field%name), field%id
+
+!      call mpp_clock_end(mpp_write_clock)
+      return
+    end subroutine mpp_write_meta_field
+
+    subroutine write_attribute( unit, name, rval, ival, cval, pack )
+!called to write metadata for non-netCDF I/O
+      integer, intent(in) :: unit
+      character(len=*), intent(in) :: name
+      real, intent(in), optional :: rval(:)
+      integer, intent(in), optional :: ival(:)
+      character(len=*), intent(in), optional :: cval
+!pack is currently ignored in this routine: only used by netCDF I/O
+      integer, intent(in), optional :: pack
+
+      if( mpp_file(unit)%nohdrs )return
+!encode text string
+      if( PRESENT(rval) )then
+          write( text,* )trim(name)//'=', rval
+      else if( PRESENT(ival) )then
+          write( text,* )trim(name)//'=', ival
+      else if( PRESENT(cval) )then
+          text = ' '//trim(name)//'='//trim(cval)
+      else
+          call mpp_error( FATAL, 'WRITE_ATTRIBUTE: one of rval, ival, cval must be present.' )
+      end if
+      if( mpp_file(unit)%format.EQ.MPP_ASCII )then
+!implies sequential access
+          write( unit,fmt='(a)' )trim(text)//char(10)
+      else                      !MPP_IEEE32 or MPP_NATIVE
+          if( mpp_file(unit)%access.EQ.MPP_SEQUENTIAL )then
+              write(unit)trim(text)//char(10)
+          else                  !MPP_DIRECT
+              write( unit,rec=mpp_file(unit)%record )trim(text)//char(10)
+              if( verbose )print '(a,i6,a,i3)', 'WRITE_ATTRIBUTE: PE=', pe, ' wrote record ', mpp_file(unit)%record
+              mpp_file(unit)%record = mpp_file(unit)%record + 1
+          end if
+      end if
+      return
+    end subroutine write_attribute
+
+  subroutine write_attribute_pio(unit, attr_id, attr_name, rval, ival, cval, pack)
+    integer,          intent(in) :: unit
+    integer,          intent(in) :: attr_id
+    character(len=*), intent(in) :: attr_name
+    real,             intent(in), optional :: rval(:)
+    integer,          intent(in), optional :: ival(:)
+    character(len=*), intent(in), optional :: cval
+    integer,          intent(in), optional :: pack
+    ! local:
+    character(len=256)    :: file_name
+    integer, allocatable  :: rval_i(:)
+    integer               :: error ! error code
+
+    ! this subroutine body is copied from mpp_io_write.inc::write_attribute_netcdf
+    ! and is modified for PIO
+
+    file_name = mpp_file(unit)%name
+
+    if( PRESENT(rval) )then ! attributes of type real
+      if( PRESENT(pack) )then
+        if( pack== 0 ) then !! here be dragons, use ival branch!...
+          call mpp_error( FATAL, &
+                  'write_attribute_pio: attempting to write internal NF_INT, currently int32, as real.' )
+        else if( pack.EQ.1 )then
+          if( KIND(rval).EQ.r8_kind )then
+            error = PIO_put_att(mpp_file(unit)%ncid, attr_id, attr_name, rval)
+          else if( KIND(rval).EQ.r4_kind )then
+            call mpp_error( WARNING, &
+                 'write_attribute_pio: attempting to write internal 32-bit real as external 64-bit.' )
+            error = PIO_put_att(mpp_file(unit)%ncid, attr_id, attr_name, rval)
+          end if
+          call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+        else if( pack.EQ.2 )then
+          error = PIO_put_att(mpp_file(unit)%ncid, attr_id, attr_name, rval)
+          call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+        else
+          call mpp_error( FATAL, 'write_attribute_pio: only legal packing values are 1,2.' )
+        end if
+      else ! no pack provided
+        error = PIO_put_att(mpp_file(unit)%ncid, attr_id, attr_name, rval)
+        call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+      end if
+    else if( PRESENT(ival) )then ! attributes of type integer
+      if( PRESENT(pack) ) then
+        if (pack ==0) then
+          if (KIND(ival).EQ.i8_kind ) then
+             call mpp_error(FATAL,'only use NF_INTs with pack=0 for now')
+          end if
+          error = PIO_put_att(mpp_file(unit)%ncid, attr_id, attr_name, ival)
+          call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+        else
+          call mpp_error( FATAL, 'write_attribute_pio: only implimented ints when pack=0, else use reals.' )
+        endif
+      else ! no pack provided
+        error = PIO_put_att(mpp_file(unit)%ncid, attr_id, attr_name, ival)
+        call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+      end if
+    else if( present(cval) )then
+      if (.NOT.cf_compliance .or. trim(attr_name).NE.'calendar') then
+        error = PIO_put_att(mpp_file(unit)%ncid, attr_id, attr_name, cval)
+      else
+        error = PIO_put_att(mpp_file(unit)%ncid, attr_id, attr_name, lowercase(cval))
+      endif
+      call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+    else
+      call mpp_error( FATAL, 'write_attribute_pio: one of rval, ival, cval must be present.' )
+    end if
+
+  end subroutine write_attribute_pio
+
+  subroutine write_attribute_pio_global(unit, attr_name, rval, ival, cval, pack)
+    integer, intent(in)             :: unit
+    character(len=*), intent(in)    :: attr_name
+    real,             intent(in), optional :: rval(:)
+    integer,          intent(in), optional :: ival(:)
+    character(len=*), intent(in), optional :: cval
+    integer,          intent(in), optional :: pack
+    ! local:
+    character(len=256)    :: file_name
+    integer, allocatable  :: rval_i(:)
+    integer               :: error ! error code
+
+    ! this subroutine body is copied from mpp_io_write.inc::write_attribute_netcdf
+    ! and is modified for PIO
+
+    file_name = mpp_file(unit)%name
+
+    if( PRESENT(rval) )then ! attributes of type real
+      if( PRESENT(pack) )then
+        if( pack== 0 ) then !! here be dragons, use ival branch!...
+          call mpp_error( FATAL, &
+                  'write_attribute_pio: attempting to write internal NF_INT, currently int32, as real.' )
+        else if( pack.EQ.1 )then
+          if( KIND(rval).EQ.r8_kind )then
+            error = PIO_put_att(mpp_file(unit)%ncid, PIO_global, attr_name, rval)
+          else if( KIND(rval).EQ.r4_kind )then
+            call mpp_error( WARNING, &
+                 'write_attribute_pio: attempting to write internal 32-bit real as external 64-bit.' )
+            error = PIO_put_att(mpp_file(unit)%ncid, PIO_global, attr_name, rval)
+          end if
+          call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+        else if( pack.EQ.2 )then
+          error = PIO_put_att(mpp_file(unit)%ncid, PIO_global, attr_name, rval)
+          call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+        else
+          call mpp_error( FATAL, 'write_attribute_pio: only legal packing values are 1,2.' )
+        end if
+      else ! no pack provided
+        error = PIO_put_att(mpp_file(unit)%ncid, PIO_global, attr_name, rval)
+        call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+      end if
+    else if( PRESENT(ival) )then ! attributes of type integer
+      if( PRESENT(pack) ) then
+        if (pack ==0) then
+          if (KIND(ival).EQ.i8_kind ) then
+             call mpp_error(FATAL,'only use NF_INTs with pack=0 for now')
+          end if
+          error = PIO_put_att(mpp_file(unit)%ncid, PIO_global, attr_name, ival)
+          call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+        else
+          call mpp_error( FATAL, 'write_attribute_pio: only implimented ints when pack=0, else use reals.' )
+        endif
+      else ! no pack provided
+        error = PIO_put_att(mpp_file(unit)%ncid, PIO_global, attr_name, ival)
+        call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+      end if
+    else if( present(cval) )then
+      if (.NOT.cf_compliance .or. trim(attr_name).NE.'calendar') then
+        error = PIO_put_att(mpp_file(unit)%ncid, PIO_global, attr_name, cval)
+      else
+        error = PIO_put_att(mpp_file(unit)%ncid, PIO_global, attr_name, lowercase(cval))
+      endif
+      call netcdf_err( error, file=mpp_file(unit), string=' Attribute='//attr_name)
+    else
+      call mpp_error( FATAL, 'write_attribute_pio: one of rval, ival, cval must be present.' )
+    end if
+
+  end subroutine write_attribute_pio_global
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                      !
+!                             MPP_WRITE                                !
+!                                                                      !
+! mpp_write is used to write data to the file on <unit> using the      !
+! file parameters supplied by mpp_open(). Axis and field definitions   !
+! must have previously been written to the file using mpp_write_meta.  !
+!                                                                      !
+! mpp_write can take 2 forms, one for distributed data and one for     !
+! non-distributed data. Distributed data refer to arrays whose two     !
+! fastest-varying indices are domain-decomposed. Distributed data      !
+! must be 2D or 3D (in space). Non-distributed data can be 0-3D.       !
+!                                                                      !
+! In all calls to mpp_write, tstamp is an optional argument. It is to  !
+! be omitted if the field was defined not to be a function of time.    !
+! Results are unpredictable if the argument is supplied for a time-    !
+! independent field, or omitted for a time-dependent field. Repeated   !
+! writes of a time-independent field are also not recommended. One     !
+! time level of one field is written per call.                         !
+!                                                                      !
+!                                                                      !
+! For non-distributed data, use                                        !
+!                                                                      !
+!  mpp_write( unit, field, data, tstamp )                              !
+!     integer, intent(in) :: unit                                      !
+!     type(fieldtype), intent(in) :: field                             !
+!     real(r8_kind), optional :: tstamp                            !
+!     data is real and can be scalar or of rank 1-3.                   !
+!                                                                      !
+! For distributed data, use                                            !
+!                                                                      !
+!  mpp_write( unit, field, domain, data, tstamp )                      !
+!     integer, intent(in) :: unit                                      !
+!     type(fieldtype), intent(in) :: field                             !
+!     type(domain2D), intent(in) :: domain                             !
+!     real(r8_kind), optional :: tstamp                            !
+!     data is real and can be of rank 2 or 3.                          !
+!                                                                      !
+!  mpp_write( unit, axis )                                             !
+!     integer, intent(in) :: unit                                      !
+!     type(axistype), intent(in) :: axis                               !
+!                                                                      !
+! This call writes the actual co-ordinate values along each space      !
+! axis. It must be called once for each space axis after all other     !
+! metadata has been written.                                           !
+!                                                                      !
+! The mpp_write package also includes the routine write_record which   !
+! performs the actual write. This routine is private to this module.   !
+!                                                                      !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#undef WRITE_RECORD_
+#define WRITE_RECORD_ write_record_r8
+#undef MPP_WRITE_2DDECOMP_2D_
+#define MPP_WRITE_2DDECOMP_2D_ mpp_write_2ddecomp_r2d_r8
+#undef MPP_WRITE_2DDECOMP_3D_
+#define MPP_WRITE_2DDECOMP_3D_ mpp_write_2ddecomp_r3d_r8
+#undef MPP_WRITE_2DDECOMP_4D_
+#define MPP_WRITE_2DDECOMP_4D_ mpp_write_2ddecomp_r4d_r8
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r8_kind)
+#include <mpp_write_2Ddecomp.h>
+
+#undef WRITE_RECORD_
+#define WRITE_RECORD_ write_record_r4
+#undef MPP_WRITE_2DDECOMP_2D_
+#define MPP_WRITE_2DDECOMP_2D_ mpp_write_2ddecomp_r2d_r4
+#undef MPP_WRITE_2DDECOMP_3D_
+#define MPP_WRITE_2DDECOMP_3D_ mpp_write_2ddecomp_r3d_r4
+#undef MPP_WRITE_2DDECOMP_4D_
+#define MPP_WRITE_2DDECOMP_4D_ mpp_write_2ddecomp_r4d_r4
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r4_kind)
+#include <mpp_write_2Ddecomp.h>
+
+#undef MPP_WRITE_COMPRESSED_1D_
+#define MPP_WRITE_COMPRESSED_1D_ mpp_write_compressed_r1d_r8
+#undef MPP_WRITE_COMPRESSED_2D_
+#define MPP_WRITE_COMPRESSED_2D_ mpp_write_compressed_r2d_r8
+#undef MPP_WRITE_COMPRESSED_3D_
+#define MPP_WRITE_COMPRESSED_3D_ mpp_write_compressed_r3d_r8
+#undef WRITE_RECORD_
+#define WRITE_RECORD_ write_record_r8
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r8_kind)
+#include <mpp_write_compressed.h>
+
+#undef MPP_WRITE_COMPRESSED_1D_
+#define MPP_WRITE_COMPRESSED_1D_ mpp_write_compressed_r1d_r4
+#undef MPP_WRITE_COMPRESSED_2D_
+#define MPP_WRITE_COMPRESSED_2D_ mpp_write_compressed_r2d_r4
+#undef MPP_WRITE_COMPRESSED_3D_
+#define MPP_WRITE_COMPRESSED_3D_ mpp_write_compressed_r3d_r4
+#undef WRITE_RECORD_
+#define WRITE_RECORD_ write_record_r4
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r4_kind)
+#include <mpp_write_compressed.h>
+
+#undef MPP_WRITE_UNLIMITED_AXIS_1D_
+#define MPP_WRITE_UNLIMITED_AXIS_1D_ mpp_write_unlimited_axis_r1d
+#undef MPP_TYPE_
+#define MPP_TYPE_ real
+#include <mpp_write_unlimited_axis.h>
+
+#undef MPP_WRITE_
+#define MPP_WRITE_ mpp_write_r0D_r8
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r8_kind)
+#undef MPP_RANK_
+#define MPP_RANK_ !
+#undef MPP_WRITE_RECORD_
+#define MPP_WRITE_RECORD_ write_record_r8( unit, field, 1, (/data/), tstamp)
+#include <mpp_write.h>
+
+#undef MPP_WRITE_
+#define MPP_WRITE_ mpp_write_r1D_r8
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r8_kind)
+#undef MPP_WRITE_RECORD_
+#define MPP_WRITE_RECORD_ write_record_r8( unit, field, size(data(:)), data, tstamp)
+#undef MPP_RANK_
+#define MPP_RANK_ (:)
+#include <mpp_write.h>
+
+#undef MPP_WRITE_
+#define MPP_WRITE_ mpp_write_r2D_r8
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r8_kind)
+#undef MPP_WRITE_RECORD_
+#define MPP_WRITE_RECORD_ write_record_r8( unit, field, size(data(:,:)), data, tstamp )
+#undef MPP_RANK_
+#define MPP_RANK_ (:,:)
+#include <mpp_write.h>
+
+#undef MPP_WRITE_
+#define MPP_WRITE_ mpp_write_r3D_r8
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r8_kind)
+#undef MPP_WRITE_RECORD_
+#define MPP_WRITE_RECORD_ write_record_r8( unit, field, size(data(:,:,:)), data, tstamp)
+#undef MPP_RANK_
+#define MPP_RANK_ (:,:,:)
+#include <mpp_write.h>
+
+#undef MPP_WRITE_
+#define MPP_WRITE_ mpp_write_r4D_r8
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r8_kind)
+#undef MPP_WRITE_RECORD_
+#define MPP_WRITE_RECORD_ write_record_r8( unit, field, size(data(:,:,:,:)), data, tstamp)
+#undef MPP_RANK_
+#define MPP_RANK_ (:,:,:,:)
+#include <mpp_write.h>
+
+#undef MPP_WRITE_
+#define MPP_WRITE_ mpp_write_r0D_r4
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r4_kind)
+#undef MPP_RANK_
+#define MPP_RANK_ !
+#undef MPP_WRITE_RECORD_
+#define MPP_WRITE_RECORD_ write_record_r4( unit, field, 1, (/data/), tstamp)
+#include <mpp_write.h>
+
+#undef MPP_WRITE_
+#define MPP_WRITE_ mpp_write_r1D_r4
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r4_kind)
+#undef MPP_WRITE_RECORD_
+#define MPP_WRITE_RECORD_ write_record_r4( unit, field, size(data(:)), data, tstamp)
+#undef MPP_RANK_
+#define MPP_RANK_ (:)
+#include <mpp_write.h>
+
+#undef MPP_WRITE_
+#define MPP_WRITE_ mpp_write_r2D_r4
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r4_kind)
+#undef MPP_WRITE_RECORD_
+#define MPP_WRITE_RECORD_ write_record_r4( unit, field, size(data(:,:)), data, tstamp )
+#undef MPP_RANK_
+#define MPP_RANK_ (:,:)
+#include <mpp_write.h>
+
+#undef MPP_WRITE_
+#define MPP_WRITE_ mpp_write_r3D_r4
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r4_kind)
+#undef MPP_WRITE_RECORD_
+#define MPP_WRITE_RECORD_ write_record_r4( unit, field, size(data(:,:,:)), data, tstamp)
+#undef MPP_RANK_
+#define MPP_RANK_ (:,:,:)
+#include <mpp_write.h>
+
+#undef MPP_WRITE_
+#define MPP_WRITE_ mpp_write_r4D_r4
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(KIND=r4_kind)
+#undef MPP_WRITE_RECORD_
+#define MPP_WRITE_RECORD_ write_record_r4( unit, field, size(data(:,:,:,:)), data, tstamp)
+#undef MPP_RANK_
+#define MPP_RANK_ (:,:,:,:)
+#include <mpp_write.h>
+
+    subroutine mpp_write_axis( unit, axis )
+      integer, intent(in) :: unit
+      type(axistype), intent(in) :: axis
+      type(fieldtype) :: field
+
+      call mpp_clock_begin(mpp_write_clock)
+      if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_WRITE: must first call mpp_io_init.' )
+      if( .NOT. mpp_file(unit)%write_on_this_pe ) then
+         call mpp_clock_end(mpp_write_clock)
+         return
+      endif
+      if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE: invalid unit number.' )
+!we convert axis to type(fieldtype) in order to call write_record
+      field = default_field
+      allocate( field%axes(1) )
+      field%axes(1) = axis
+      allocate( field%size(1) )
+      field%size(1) = axis%len
+      field%id = axis%id
+
+      field%name = axis%name
+      field%longname = axis%longname
+      field%units = axis%units
+
+      if(ASSOCIATED(axis%data))then
+        allocate( field%axes(1)%data(size(axis%data) ))
+        field%axes(1)%data = axis%data
+        call write_record( unit, field, axis%len, axis%data )
+      elseif(ASSOCIATED(axis%idata))then
+        allocate( field%axes(1)%data(size(axis%idata) ))
+        field%axes(1)%data = REAL(axis%idata)
+        field%pack=4
+        call write_record( unit, field, axis%len, REAL(axis%idata) )
+      else
+        call mpp_error( FATAL, 'MPP_WRITE_AXIS: No data associated with axis.' )
+      endif
+
+      deallocate(field%axes(1)%data)
+      deallocate(field%axes,field%size)
+
+      call mpp_clock_end(mpp_write_clock)
+      return
+    end subroutine mpp_write_axis
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                      !
+!                          MPP_COPY_META                               !
+!                                                                      !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    subroutine mpp_copy_meta_global( unit, gatt )
+!writes a global metadata attribute to unit <unit>
+!attribute <name> can be an real, integer or character
+!one and only one of rval, ival, and cval should be present
+!the first found will be used
+!for a non-netCDF file, it is encoded into a string "GLOBAL <name> <val>"
+      integer, intent(in) :: unit
+      type(atttype), intent(in) :: gatt
+      integer :: len, error
+
+#ifndef use_PIO
+      if( .NOT.module_is_initialized    )call mpp_error( FATAL, 'MPP_WRITE_META: must first call mpp_io_init.' )
+      if( .NOT. mpp_file(unit)%write_on_this_pe )return
+      if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
+      if( mpp_file(unit)%initialized ) then
+!     File has already been written to and needs to be returned to define mode.
+#ifdef use_netCDF
+        error = NF_REDEF(mpp_file(unit)%ncid)
+#endif
+        mpp_file(unit)%initialized = .false.
+      endif
+!           call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
+#ifdef use_netCDF
+      if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
+         if( gatt%type.EQ.NF_CHAR )then
+            len = gatt%len
+            call write_attribute_netcdf( unit, NF_GLOBAL, gatt%name, cval=gatt%catt(1:len) )
+         else
+            call write_attribute_netcdf( unit, NF_GLOBAL, gatt%name, rval=gatt%fatt )
+         endif
+      else
+         if( gatt%type.EQ.NF_CHAR )then
+            len=gatt%len
+            call write_attribute( unit, 'GLOBAL '//trim(gatt%name), cval=gatt%catt(1:len) )
+         else
+            call write_attribute( unit, 'GLOBAL '//trim(gatt%name), rval=gatt%fatt )
+         endif
+     end if
+#else
+     call mpp_error( FATAL, 'MPP_READ currently requires use_netCDF option' )
+#endif
+      return
+#else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+#endif
+    end subroutine mpp_copy_meta_global
+
+    subroutine mpp_copy_meta_axis( unit, axis, domain )
+!load the values in an axistype (still need to call mpp_write)
+!write metadata attributes for axis.  axis is declared inout
+!because the variable and dimension ids are altered
+
+      integer, intent(in) :: unit
+      type(axistype), intent(inout) :: axis
+      type(domain1D), intent(in), optional :: domain
+      character(len=512) :: text
+      integer :: i, len, is, ie, isg, ieg, error
+
+#ifndef use_PIO
+!      call mpp_clock_begin(mpp_write_clock)
+      if( .NOT.module_is_initialized    )call mpp_error( FATAL, 'MPP_WRITE_META: must first call mpp_io_init.' )
+      if( .NOT. mpp_file(unit)%write_on_this_pe ) then
+!         call mpp_clock_end(mpp_write_clock)
+         return
+      endif
+      if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
+      if( mpp_file(unit)%initialized )  then
+!     File has already been written to and needs to be returned to define mode.
+#ifdef use_netCDF
+        error = NF_REDEF(mpp_file(unit)%ncid)
+#endif
+        mpp_file(unit)%initialized = .false.
+      endif
+!           call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
+
+! redefine domain if present
+      if( PRESENT(domain) )then
+          axis%domain = domain
+      else
+          axis%domain = NULL_DOMAIN1D
+      end if
+
+#ifdef use_netCDF
+!write metadata
+      if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
+
+!write axis def
+          if( ASSOCIATED(axis%data) )then !space axis
+              if( mpp_file(unit)%fileset.EQ.MPP_MULTI .AND. axis%domain.NE.NULL_DOMAIN1D )then
+                  call mpp_get_compute_domain( axis%domain, is, ie )
+                  call mpp_get_global_domain( axis%domain, isg, ieg )
+                  ie  = ie + axis%shift
+                  ieg = ieg + axis%shift
+                  error = NF_DEF_DIM( mpp_file(unit)%ncid, axis%name, ie-is+1, axis%did )
+              else
+                  error = NF_DEF_DIM( mpp_file(unit)%ncid, axis%name, size(axis%data(:)), axis%did )
+              end if
+              call netcdf_err( error, mpp_file(unit), axis )
+              error = NF_DEF_VAR( mpp_file(unit)%ncid, axis%name, NF_FLOAT, 1, (/axis%did/), axis%id )
+              call netcdf_err( error, mpp_file(unit), axis )
+          else                            !time axis
+              error = NF_DEF_DIM( mpp_file(unit)%ncid, axis%name, NF_UNLIMITED, axis%did )
+              call netcdf_err( error, mpp_file(unit), axis )
+              error = NF_DEF_VAR( mpp_file(unit)%ncid, axis%name, NF_DOUBLE, 1, (/axis%did/), axis%id )
+              call netcdf_err( error, mpp_file(unit), axis )
+              mpp_file(unit)%id = axis%id !file ID is the same as time axis varID
+              mpp_file(unit)%recdimid = axis%did ! record dimension id
+          end if
+      else
+          varnum = varnum + 1
+          axis%id = varnum
+          axis%did = varnum
+!write axis def
+          write( text, '(a,i4,a)' )'AXIS ', axis%id, ' name'
+          call write_attribute( unit, trim(text), cval=axis%name )
+          write( text, '(a,i4,a)' )'AXIS ', axis%id, ' size'
+          if( ASSOCIATED(axis%data) )then !space axis
+              if( mpp_file(unit)%fileset.EQ.MPP_MULTI .AND. axis%domain.NE.NULL_DOMAIN1D )then
+                  call mpp_get_compute_domain(axis%domain, is, ie)
+                  call write_attribute( unit, trim(text), ival=(/ie-is+1/) ) ! ??? is, ie is not initialized
+              else
+                  call write_attribute( unit, trim(text), ival=(/size(axis%data(:))/) )
+              end if
+          else                            !time axis
+              if( mpp_file(unit)%id.NE.-1 ) &
+                   call mpp_error( FATAL, 'MPP_WRITE_META_AXIS: There is already a time axis for this file.' )
+              call write_attribute( unit, trim(text), ival=(/0/) ) !a size of 0 indicates time axis
+              mpp_file(unit)%id = axis%id
+          end if
+      end if
+!write axis attributes
+
+      do i=1,axis%natt
+         if( axis%Att(i)%name.NE.default_att%name )then
+            if( axis%Att(i)%type.EQ.NF_CHAR )then
+               len = axis%Att(i)%len
+               call mpp_write_meta( unit, axis%id, axis%Att(i)%name, cval=axis%Att(i)%catt(1:len) )
+            else
+               call mpp_write_meta( unit, axis%id, axis%Att(i)%name, rval=axis%Att(i)%fatt)
+            endif
+         endif
+      enddo
+
+      if( mpp_file(unit)%threading.EQ.MPP_MULTI .AND. mpp_file(unit)%fileset.EQ.MPP_MULTI &
+         .AND. axis%domain.NE.NULL_DOMAIN1D )then
+          call mpp_write_meta( unit, axis%id, 'domain_decomposition', ival=(/isg,ieg,is,ie/) )
+      end if
+      if( verbose )print '(a,2i6,x,a,2i3)', 'MPP_WRITE_META: Wrote axis metadata, pe, unit, axis%name, axis%id, axis%did=', &
+           pe, unit, trim(axis%name), axis%id, axis%did
+#else
+      call mpp_error( FATAL, 'MPP_READ currently requires use_netCDF option' )
+#endif
+!      call mpp_clock_end(mpp_write_clock)
+      return
+#else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+#endif
+    end subroutine mpp_copy_meta_axis
+
+    subroutine mpp_copy_meta_field( unit, field, axes )
+!useful for copying field metadata from a previous call to mpp_read_meta
+!define field: must have already called mpp_write_meta(axis) for each axis
+      integer, intent(in) :: unit
+      type(fieldtype), intent(inout) :: field
+      type(axistype), intent(in), optional :: axes(:)
+!this array is required because of f77 binding on netCDF interface
+      integer, allocatable :: axis_id(:)
+      real :: a, b
+      integer :: i, error
+
+#ifndef use_PIO
+!      call mpp_clock_begin(mpp_write_clock)
+      if( .NOT.module_is_initialized    )call mpp_error( FATAL, 'MPP_WRITE_META: must first call mpp_io_init.' )
+      if( .NOT. mpp_file(unit)%write_on_this_pe ) then
+!         call mpp_clock_end(mpp_write_clock)
+         return
+      endif
+      if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
+      if( mpp_file(unit)%initialized )  then
+!     File has already been written to and needs to be returned to define mode.
+#ifdef use_netCDF
+        error = NF_REDEF(mpp_file(unit)%ncid)
+#endif
+        mpp_file(unit)%initialized = .false.
+      endif
+!           call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
+
+       if( field%pack.NE.1 .AND. field%pack.NE.2 )then
+            if( field%pack.NE.4 .AND. field%pack.NE.8 ) &
+               call mpp_error( FATAL, 'MPP_WRITE_META_FIELD: only legal packing values are 1,2,4,8.' )
+      end if
+
+      if (PRESENT(axes)) then
+         deallocate(field%axes)
+         deallocate(field%size)
+         allocate(field%axes(size(axes(:))))
+         allocate(field%size(size(axes(:))))
+         field%axes = axes
+         do i=1,size(axes(:))
+            if (ASSOCIATED(axes(i)%data)) then
+               field%size(i) = size(axes(i)%data(:))
+            else
+               field%size(i) = 1
+               field%time_axis_index = i
+            endif
+         enddo
+      endif
+
+      if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
+#ifdef use_netCDF
+          allocate( axis_id(size(field%axes(:))) )
+          do i = 1,size(field%axes(:))
+             axis_id(i) = field%axes(i)%did
+          end do
+!write field def
+          select case (field%pack)
+              case(1)
+                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_DOUBLE, &
+                                     size(field%axes(:)), axis_id, field%id )
+              case(2)
+                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_FLOAT, &
+                                     size(field%axes(:)), axis_id, field%id )
+              case(4)
+!                 if( field%scale.EQ.default_field%scale .OR. field%add.EQ.default_field%add ) &
+!                      call mpp_error( FATAL, 'MPP_WRITE_META_FIELD: scale and add must be supplied when pack=4.' )
+                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_SHORT, &
+                                     size(field%axes(:)), axis_id, field%id )
+              case(8)
+!                 if( field%scale.EQ.default_field%scale .OR. field%add.EQ.default_field%add ) &
+!                      call mpp_error( FATAL, 'MPP_WRITE_META_FIELD: scale and add must be supplied when pack=8.' )
+                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_BYTE, &
+                                     size(field%axes(:)), axis_id, field%id )
+              case default
+                  call mpp_error( FATAL, 'MPP_WRITE_META_FIELD: only legal packing values are 1,2,4,8.' )
+          end select
+          deallocate( axis_id )
+#endif
+      else
+          varnum = varnum + 1
+          field%id = varnum
+          if( field%pack.NE.default_field%pack ) &
+           call mpp_error( WARNING, 'MPP_WRITE_META: Packing is currently available only on netCDF files.' )
+!write field def
+          write( text, '(a,i4,a)' )'FIELD ', field%id, ' name'
+          call write_attribute( unit, trim(text), cval=field%name )
+          write( text, '(a,i4,a)' )'FIELD ', field%id, ' axes'
+          call write_attribute( unit, trim(text), ival=field%axes(:)%did )
+      end if
+!write field attributes: these names follow netCDF conventions
+      call mpp_write_meta( unit, field%id, 'long_name', cval=field%longname )
+      if (lowercase(trim(field%units)).ne.'none' .OR. .NOT.cf_compliance) then
+        call mpp_write_meta( unit, field%id, 'units',     cval=field%units    )
+      endif
+!all real attributes must be written as packed
+      if( (field%min.NE.default_field%min) .AND. (field%max.NE.default_field%max) )then
+          if( field%pack.EQ.1 .OR. field%pack.EQ.2 )then
+              call mpp_write_meta( unit, field%id, 'valid_range', rval=(/field%min,field%max/), pack=field%pack )
+          else
+              a = nint((field%min-field%add)/field%scale)
+              b = nint((field%max-field%add)/field%scale)
+              call mpp_write_meta( unit, field%id, 'valid_range', rval=(/a,  b  /), pack=field%pack )
+          end if
+      else if( field%min.NE.default_field%min )then
+          if( field%pack.EQ.1 .OR. field%pack.EQ.2 )then
+              call mpp_write_meta( unit, field%id, 'valid_min', rval=field%min, pack=field%pack )
+          else
+              a = nint((field%min-field%add)/field%scale)
+              call mpp_write_meta( unit, field%id, 'valid_min', rval=a, pack=field%pack )
+          end if
+      else if( field%max.NE.default_field%max )then
+          if( field%pack.EQ.1 .OR. field%pack.EQ.2 )then
+              call mpp_write_meta( unit, field%id, 'valid_max', rval=field%max, pack=field%pack )
+          else
+              a = nint((field%max-field%add)/field%scale)
+              call mpp_write_meta( unit, field%id, 'valid_max', rval=a, pack=field%pack )
+          end if
+      end if
+      if( field%missing.NE.default_field%missing )then
+          if( field%pack.EQ.1 .OR. field%pack.EQ.2 )then
+              call mpp_write_meta( unit, field%id, 'missing_value', rval=field%missing, pack=field%pack )
+          else
+              a = nint((field%missing-field%add)/field%scale)
+              call mpp_write_meta( unit, field%id, 'missing_value', rval=a, pack=field%pack )
+          end if
+      end if
+      if( field%fill.NE.default_field%fill )then
+          if( field%pack.EQ.1 .OR. field%pack.EQ.2 )then
+              call mpp_write_meta( unit, field%id, '_FillValue', rval=field%missing, pack=field%pack )
+          else
+              a = nint((field%fill-field%add)/field%scale)
+              call mpp_write_meta( unit, field%id, '_FillValue', rval=a, pack=field%pack )
+          end if
+      end if
+      if( field%pack.NE.1 .AND. field%pack.NE.2 )then
+          call mpp_write_meta( unit, field%id, 'packing', ival=field%pack )
+          if( field%scale.NE.default_field%scale ) &
+                                 call mpp_write_meta( unit, field%id, 'scale_factor',  rval=field%scale )
+          if( field%add.NE.default_field%add   ) &
+                                 call mpp_write_meta( unit, field%id, 'add_offset',    rval=field%add )
+      end if
+      if( verbose )print '(a,2i6,x,a,i3)', 'MPP_WRITE_META: Wrote field metadata: pe, unit, field%name, field%id=', &
+           pe, unit, trim(field%name), field%id
+
+!      call mpp_clock_end(mpp_write_clock)
+      return
+#else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+#endif
+    end subroutine mpp_copy_meta_field
+
+    subroutine mpp_modify_axis_meta( axis, name, units, longname, cartesian, data )
+
+      type(axistype), intent(inout) :: axis
+      character(len=*), intent(in), optional :: name, units, longname, cartesian
+      real, dimension(:), intent(in), optional :: data
+
+#ifndef use_PIO
+      if (PRESENT(name)) axis%name = trim(name)
+      if (PRESENT(units)) axis%units = trim(units)
+      if (PRESENT(longname)) axis%longname = trim(longname)
+      if (PRESENT(cartesian)) axis%cartesian = trim(cartesian)
+      if (PRESENT(data)) then
+         axis%len = size(data(:))
+         if (ASSOCIATED(axis%data)) deallocate(axis%data)
+         allocate(axis%data(axis%len))
+         axis%data = data
+      endif
+
+      return
+#else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+#endif
+    end subroutine mpp_modify_axis_meta
+
+    subroutine mpp_modify_field_meta( field, name, units, longname, min, max, missing, axes )
+
+      type(fieldtype), intent(inout) :: field
+      character(len=*), intent(in), optional :: name, units, longname
+      real, intent(in), optional :: min, max, missing
+      type(axistype), dimension(:), intent(inout), optional :: axes
+
+#ifndef use_PIO
+      if (PRESENT(name)) field%name = trim(name)
+      if (PRESENT(units)) field%units = trim(units)
+      if (PRESENT(longname)) field%longname = trim(longname)
+      if (PRESENT(min)) field%min = min
+      if (PRESENT(max)) field%max = max
+      if (PRESENT(missing)) field%missing = missing
+!      if (PRESENT(axes)) then
+!         axis%len = size(data(:))
+!         deallocate(axis%data)
+!         allocate(axis%data(axis%len))
+!         axis%data = data
+!      endif
+
+      return
+#else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+#endif
+    end subroutine mpp_modify_field_meta
+
+
+!> \brief Fills in a fieldtype variable, and is used with the diag_manager when using
+!! fms2_io
+    subroutine fillin_fieldtype(field, axes, name, units, longname,&
+         min, max, missing, fill, scale, add, pack, time_method, standard_name, checksum)
+!define field: must have already called mpp_write_meta(axis) for each axis
+      type(fieldtype), intent(inout) :: field
+      type(axistype), intent(in) :: axes(:)
+      character(len=*), intent(in) :: name, units, longname
+      real, intent(in), optional :: min, max, missing, fill, scale, add
+      integer, intent(in), optional :: pack
+      character(len=*), intent(in), optional :: time_method
+      character(len=*), intent(in), optional :: standard_name
+      integer(i8_kind), dimension(:), intent(in), optional :: checksum
+!this array is required because of f77 binding on netCDF interface
+      integer, allocatable :: axis_id(:)
+      real :: a, b
+      integer :: i, istat, ishift, jshift
+      character(len=64) :: checksum_char
+
+!      call mpp_clock_begin(mpp_write_clock)
+
+      !--- figure out the location of data, this is needed in mpp_write.
+      !--- for NON-symmetry domain, the position is not an issue.
+      !--- we may need to rethink how to address the symmetric issue.
+      ishift = 0; jshift = 0
+      do i = 1, size(axes(:))
+         select case ( lowercase( axes(i)%cartesian ) )
+         case ( 'x' )
+            ishift = axes(i)%shift
+         case ( 'y' )
+            jshift = axes(i)%shift
+         end select
+      end do
+
+      field%position = CENTER
+      if(ishift == 1 .AND. jshift == 1) then
+         field%position = CORNER
+      else if(ishift == 1) then
+         field%position = EAST
+      else if(jshift == 1) then
+         field%position = NORTH
+      endif
+
+!pre-existing pointers need to be nullified
+      if( ASSOCIATED(field%axes) ) DEALLOCATE(field%axes, stat=istat)
+      if( ASSOCIATED(field%size) ) DEALLOCATE(field%size, stat=istat)
+!fill in field metadata
+      field%name = name
+      field%units = units
+      field%longname = longname
+      allocate( field%axes(size(axes(:))) )
+      field%axes = axes
+      field%ndim = size(axes(:))
+      field%time_axis_index = -1 !this value will never match any axis index
+!size is buffer area for the corresponding axis info: it is required to buffer this info in the fieldtype
+!because axis might be reused in different files
+      allocate( field%size(size(axes(:))) )
+      do i = 1,size(axes(:))
+         if( ASSOCIATED(axes(i)%data) )then !space axis
+             field%size(i) = size(axes(i)%data(:))
+         else               !time
+             field%size(i) = 1
+             field%time_axis_index = i
+         end if
+      end do
+!attributes
+      if( PRESENT(min) )          field%min           = min
+      if( PRESENT(max) )          field%max           = max
+      if( PRESENT(scale) )        field%scale         = scale
+      if( PRESENT(add) )          field%add           = add
+      if( PRESENT(standard_name)) field%standard_name = standard_name
+      if( PRESENT(missing) )      field%missing       = missing
+      if( PRESENT(fill) )         field%fill          = fill
+      field%checksum      = 0
+      if( PRESENT(checksum) )     field%checksum(1:size(checksum)) = checksum(:)
+
+      ! Issue warning if fill and missing are different
+      if ( (present(fill).and.present(missing)) .and. (field%missing .ne. field%fill) ) then
+         call mpp_error(WARNING, 'MPP_WRITE_META: NetCDF attributes _FillValue and missing_value should be equal.')
+      end if
+!pack is currently used only for netCDF
+      field%pack = 2        !default write 32-bit floats
+      if( PRESENT(pack) )field%pack = pack
+
+      return
+    end subroutine fillin_fieldtype
+

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -221,6 +221,9 @@ private
   public :: mpp_broadcast, mpp_init, mpp_exit
   public :: mpp_gather, mpp_scatter, mpp_alltoall
   public :: mpp_type, mpp_byte, mpp_type_create, mpp_type_free
+#ifdef use_libMPI
+  public :: get_mpp_comm
+#endif
 
   !*********************************************************************
   !

--- a/mpp/mpp_io.F90
+++ b/mpp/mpp_io.F90
@@ -355,6 +355,20 @@ use mpp_domains_mod, only: domainUG, &
 use platform_mod
 !----------
 
+#ifdef use_PIO
+use pio,          only : File_desc_t, IO_desc_t, var_desc_t
+use pio,          only : PIO_put_att, PIO_def_dim, PIO_def_var, PIO_put_var
+use pio,          only : PIO_write_darray, PIO_read_darray
+use pio,          only : PIO_enddef, PIO_redef, PIO_def_var_deflate
+use pio,          only : PIO_GLOBAL, PIO_UNLIMITED, PIO_OFFSET_KIND
+use pio,          only : PIO_CHAR, PIO_INT, PIO_REAL, PIO_DOUBLE
+use pio,          only : PIO_closefile, PIO_syncfile
+use pio,          only : PIO_inquire_variable, PIO_inquire_dimension, PIO_inquire, PIO_inq_dimid
+use pio,          only : PIO_inq_varid, PIO_inq_attname, PIO_inq_att, PIO_get_att, PIO_get_var
+use pio,          only : pio_inq_varndims
+use mpp_pio_mod,  only : mpp_pio_init, mpp_pio_stage_ioDesc, mpp_pio_openfile
+#endif
+
 implicit none
 private
 
@@ -456,6 +470,9 @@ type :: atttype
      integer                 :: id, type, natt, ndim
      type(atttype), pointer  :: Att(:) =>NULL()
      integer                 :: position ! indicate the location of the data ( CENTER, NORTH, EAST, CORNER )
+#ifdef use_PIO
+     type(IO_desc_t), pointer:: ioDesc =>NULL()
+#endif
   end type fieldtype
 
   !> @ingroup mpp_io_mod
@@ -487,6 +504,9 @@ type :: atttype
 !ug support
      type(domainUG),pointer :: domain_ug => null() !Is this actually pointed to?
 !----------
+#ifdef use_PIO
+     type (File_desc_t) :: fileDesc
+#endif
   end type filetype
 
 !> @addtogroup mpp_io_mod
@@ -1119,7 +1139,11 @@ contains
 #include <mpp_io_misc.inc>
 #include <mpp_io_connect.inc>
 #include <mpp_io_read.inc>
+#ifndef use_PIO
 #include <mpp_io_write.inc>
+#else
+#include <mpp_pio_write.inc>
+#endif
 
 !----------
 !ug support

--- a/mpp/mpp_pio.F90
+++ b/mpp/mpp_pio.F90
@@ -1,0 +1,531 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+!-----------------------------------------------------------------------
+!                 ParallelIO (PIO) Module for FMS
+!
+! AUTHOR: A. Altuntas (altuntas@ucar.edu)
+!         National Center for Atmospheric Research
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 2 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! For the full text of the GNU General Public License,
+! write to: Free Software Foundation, Inc.,
+!           675 Mass Ave, Cambridge, MA 02139, USA.
+!-----------------------------------------------------------------------
+
+! <CONTACT EMAIL="altuntas@ucar.edu">
+!   A. Altuntas
+! </CONTACT>
+
+! <OVERVIEW>
+!   <TT>mpp_pio_mod</TT>, is ... TODO
+! </OVERVIEW>
+
+! <DESCRIPTION>
+!   TODO
+! </DESCRIPTION>
+
+module mpp_pio_mod
+
+! PIO requires MPI:
+#ifndef use_libMPI
+#undef use_PIO
+#endif
+
+#ifdef use_PIO
+
+#include <fms_platform.h>
+
+  use mpp_mod,  only : input_nml_file
+  use mpp_mod,  only : mpp_pe, mpp_root_pe, mpp_npes, get_mpp_comm, mpp_max
+  use mpp_mod,  only : mpp_error, FATAL, WARNING, lowercase
+  use pio,      only : PIO_init, pio_createfile, PIO_initdecomp
+  use pio,      only : pio_createfile, pio_openfile, pio_file_is_open
+  use pio,      only : File_desc_t, var_desc_t, iosystem_desc_t, IO_desc_t
+  use pio,      only : pio_write, pio_clobber, pio_nowrite
+  use pio,      only : PIO_put_att, pio_inquire, PIO_get_local_array_size
+  use pio,      only : pio_iotype_netcdf, pio_iotype_pnetcdf
+  use pio,      only : PIO_set_log_level
+  use pio,      only : PIO_DOUBLE, PIO_REAL, PIO_INT
+  use pio,      only : PIO_64BIT_OFFSET, PIO_64BIT_DATA
+  use mpp_parameter_mod,  only : MPP_WRONLY, MPP_RDONLY, MPP_APPEND, MPP_OVERWR
+  use mpp_parameter_mod,  only : CENTER, EAST, NORTH, CORNER
+  use mpp_domains_mod,    only : domain2d, mpp_get_compute_domain, mpp_get_global_domain
+  use mpp_domains_mod,    only : mpp_get_data_domain, mpp_get_memory_domain
+
+  implicit none
+  private
+
+#include <netcdf.inc>
+
+  public :: mpp_pio_init
+  public :: mpp_pio_stage_ioDesc
+  public :: mpp_pio_openfile
+
+  character(len=64)   :: pio_netcdf_format, pio_typename
+  integer             :: pio_numiotasks, pio_rearranger, pio_root, pio_stride
+  namelist /mpp_pio_nml/ pio_netcdf_format, pio_numiotasks, pio_rearranger, &
+                         pio_root, pio_stride, pio_typename
+
+  type(iosystem_desc_t) :: pio_iosystem     ! The ParallelIO system set up by PIO_init
+  integer               :: pio_iotype       ! PIO_IOTYPE_NETCDF or PNETCDF
+  integer               :: pio_optbase = 1  ! Start index of I/O processors
+
+  integer, parameter :: npos = 8 ! EAST=3, NORTH=5, CENTER=7, CORNER=8
+
+  ! below variables (maxl3, maxl4, lens3, lens4, ndlo) are used to match iodesc pointers
+  integer, parameter :: maxl3 = 5 ! max number of lengths for dim=3 for iodesc bookkeeping
+  integer, parameter :: maxl4 = 5 ! max number of lengths for dim=4 for iodesc bookkeeping
+  integer, dimension(maxl3) :: lens3 = 0 ! array of dimension lengths for 3rd dimension
+  integer, dimension(maxl4) :: lens4 = 0 ! array of dimension lengths for 4th dimension
+  integer, parameter :: ndlo = 5 ! number of potential dimension layouts. see get_dlo function.
+
+  ! IO descriptions
+  type ioDesc_t
+     type (IO_desc_t), pointer :: ptr => NULL()
+  end type ioDesc_t
+  type (ioDesc_t), dimension(npos,ndlo,maxl3,maxl4) :: ioDesc_i
+  type (ioDesc_t), dimension(npos,ndlo,maxl3,maxl4) :: ioDesc_r
+  type (ioDesc_t), dimension(npos,ndlo,maxl3,maxl4) :: ioDesc_d
+
+  contains
+
+  subroutine mpp_pio_init()
+    ! local
+    integer :: unit_begin, unit_end, unit_nml, io_status, unit
+    logical :: opened
+    integer :: pe, npes, localcomm
+    integer :: numAggregator = 0 !TODO
+    integer :: ierr
+
+    ! default values for pio_nml namelist vars:
+    pio_netcdf_format = "64bit_offset"
+    pio_typename = "netcdf"
+    pio_numiotasks = 1
+    pio_rearranger = 1 
+    pio_root = 1
+    pio_stride = 36
+
+    ! read mpp_pio_nml namelist
+#ifdef INTERNAL_FILE_NML
+      read (input_nml_file, mpp_pio_nml, iostat=io_status)
+#else
+      unit_begin = 103
+      unit_end   = 512
+      do unit_nml = unit_begin, unit_end
+         inquire(unit_nml, OPENED=opened )
+         if( .NOT.opened )exit
+      end do
+
+      open(unit_nml,file='input.nml', iostat=io_status)
+      read(unit_nml,mpp_pio_nml,iostat=io_status)
+      close(unit_nml)
+#endif
+
+    if (trim(pio_typename) == "netcdf") then
+      pio_iotype = pio_iotype_netcdf
+    elseif (trim(pio_typename) == "pnetcdf") then
+      pio_iotype = pio_iotype_pnetcdf
+    else
+      call mpp_error(FATAL,'Unknown PIO filetype')
+    endif
+
+    pe = mpp_pe()
+    npes = mpp_npes()
+    localcomm = get_mpp_comm()
+
+    if (pe == mpp_root_pe()) then
+      print *, "mpp_pio_nml", trim(pio_netcdf_format), pio_numiotasks, pio_rearranger, &
+                         pio_root, pio_stride, trim(pio_typename)
+
+    endif
+
+    ! TODO
+    ! add checks regarding the consistency of npes, numiotasksm stride, etc.
+
+    !initialize PIO
+    call PIO_init(    &
+      pe,             & ! MPI rank
+      localcomm,      & ! MPI communicator
+      pio_numiotasks, & ! Number of iotasks
+      numAggregator,  & ! number of aggregators to use
+      pio_stride,     & ! stride
+      pio_rearranger, & ! form of rearrangement
+      pio_iosystem,   & ! The ParallelIO system set up by PIO_init
+      pio_optbase )     ! Start index of I/O processors (optional)
+
+    !ierr = PIO_set_log_level(1)
+
+    !print *, "initialized PIO: ", localcomm
+
+  end subroutine mpp_pio_init
+
+  subroutine mpp_pio_stage_ioDesc(basetype_nf, domain, ioDesc, pos, ndim, time_axis_index, dlen)
+    integer,          intent(in) :: basetype_nf
+    type(domain2D),   intent(in) :: domain
+    type (IO_desc_t), pointer    :: ioDesc
+    integer,          intent(in) :: pos ! EAST=3, NORTH=5, CENTER=7, CORNER=8
+    integer,          intent(in) :: ndim
+    integer,          intent(in) :: time_axis_index
+    integer, dimension(:), pointer :: dlen
+    ! local
+    type (IO_desc_t), pointer :: ioDesc_wrk
+    integer :: ni, nj
+    integer :: local_size
+    integer :: global_size
+    integer :: nig, njg, nk
+    integer :: is, ie, js, je
+    integer :: isd, ied, jsd, jed
+    integer :: ism, iem, jsm, jem
+    integer :: ioff, joff
+    integer :: i,j,k,l,n
+    integer, dimension(:), allocatable :: dof
+    logical :: decomp_init_needed
+    integer :: dlo ! dimension layout index
+
+    ioDesc_wrk => null()
+
+    if (associated(ioDesc)) return
+
+    ! check if cell position is valid
+    select case (pos)
+      case(EAST)
+      case(NORTH)
+      case(CENTER)
+      case(CORNER)
+      case default
+        print *, "field position: ", pos
+        call mpp_error(FATAL,'mpp_pio_stage_ioDesc - Unknown field position')
+    end select
+
+    ! determine which ioDesc is the corresponding one
+    call get_ioDesc_ptr(pos, ndim, dlen, basetype_nf, time_axis_index, ioDesc_wrk)
+
+    decomp_init_needed = .false.
+    if (.not. associated(ioDesc_wrk)) then
+      allocate(ioDesc_wrk)
+      decomp_init_needed = .true.
+    endif
+
+    ! If not already done, initialize the corresponding ioDesc
+    if (decomp_init_needed) then
+
+      call mpp_get_compute_domain( domain, is, ie, js, je, xsize = ni, ysize = nj, position=pos)
+      call mpp_get_global_domain ( domain, xsize = nig, ysize = njg, position=pos)
+      call mpp_get_data_domain   ( domain, isd, ied, jsd, jed, position=pos )
+      call mpp_get_memory_domain ( domain, ism, iem, jsm, jem, position=pos )
+
+      ! determine the index offsets:
+      ioff = 1 - is
+      joff = 1 - js
+      call mpp_max(ioff)
+      call mpp_max(joff)
+
+      if (ndim == 2) then
+        global_size = nig*njg
+        local_size = ni*nj
+        allocate(dof(local_size))
+
+        n = 1
+        do j=js+joff,je+joff
+          do i=is+ioff,ie+ioff
+            dof(n) = i + (j-1)*nig
+            n = n+1
+          enddo
+        enddo
+
+        ! sanity check:
+        if (any(dof<1) .or. any(dof>global_size)) then
+          print *, "global size: ", global_size, &
+                   "minval(dof) ", minval(dof),  &
+                   "maxval(dof) ", maxval(dof)
+          call mpp_error(FATAL,'error in dof construction')
+        endif
+
+        ! initialize decomposition
+        call PIO_initdecomp(pio_iosystem, basetype_nf, (/nig, njg/), dof, ioDesc_wrk)
+
+      else if (ndim == 3) then
+        ! construct dof
+        global_size = nig*njg*dlen(3)
+        local_size = ni*nj*dlen(3)
+        allocate(dof(local_size))
+
+        n = 1
+        do k=1,dlen(3)
+          do j=js+joff,je+joff
+            do i=is+ioff,ie+ioff
+              dof(n) = i + (j-1)*nig + (k-1)*nig*njg
+              n = n+1
+            enddo
+          enddo
+        enddo
+
+        ! sanity check:
+        if (any(dof<1) .or. any(dof>global_size)) then
+          print *, "global size: ", global_size, &
+                   "minval(dof) ", minval(dof),  &
+                   "maxval(dof) ", maxval(dof)
+          call mpp_error(FATAL,'error in dof construction')
+        endif
+
+        ! initialize decomposition
+        call PIO_initdecomp(pio_iosystem, basetype_nf, (/nig, njg, dlen(3)/), dof, ioDesc_wrk)
+
+      else if (ndim == 4) then
+        ! construct dof
+        global_size = nig*njg*dlen(3)*dlen(4)
+        local_size = ni*nj*dlen(3)*dlen(4)
+        allocate(dof(local_size))
+
+        n = 1
+        do l=1,dlen(4)
+          do k=1,dlen(3)
+            do j=js+joff,je+joff
+              do i=is+ioff,ie+ioff
+                dof(n) = i + (j-1)*nig + (k-1)*nig*njg
+                n = n+1
+              enddo
+            enddo
+          enddo
+        enddo
+
+        ! sanity check:
+        if (any(dof<1) .or. any(dof>global_size)) then
+          print *, "global size: ", global_size, &
+                   "minval(dof) ", minval(dof),  &
+                   "maxval(dof) ", maxval(dof)
+          call mpp_error(FATAL,'error in dof construction')
+        endif
+
+        ! initialize decomposition
+        call PIO_initdecomp(pio_iosystem, basetype_nf, (/nig, njg, dlen(3), dlen(4)/), dof, ioDesc_wrk)
+
+      else
+        call mpp_error(FATAL,'mpp_pio_decomp_init - Unsupported number of dimensions')
+      endif
+    else
+      ! Check if the size of the decomposition to be adopted is compatible with the size of the field:
+      ! to be adopted is the right size:
+      call mpp_get_compute_domain( domain, is, ie, js, je, xsize = ni, ysize = nj, position=pos)
+      select case (ndim)
+        case(2)
+          local_size = ni*nj
+        case(3)
+          local_size = ni*nj*dlen(3)
+        case(4)
+          local_size = ni*nj*dlen(3)*dlen(4)
+        case default
+          call mpp_error(FATAL,'Incompatible ndim in mpp_pio_stage_ioDesc.')
+      end select
+
+      if (local_size /= PIO_get_local_array_size(ioDesc_wrk))then
+          print *, mpp_pe(), "local_size:", local_size, "decomp.size:", PIO_get_local_array_size(ioDesc_wrk)
+          print *, mpp_pe(), "ni:",ni, "nj:",nj, "pos:",pos
+          call mpp_error(FATAL,'incompatible local_size and ioDesc.')
+      endif
+    endif
+
+    ioDesc => ioDesc_wrk
+
+  end subroutine mpp_pio_stage_ioDesc
+
+  function mpp_pio_openfile(file_desc, file_name, action_flag, ncid)
+    type(File_desc_t),  intent(inout)         :: file_desc
+    character(len=*),   intent(in)            :: file_name
+    integer,            intent(in)            :: action_flag
+    integer,            intent(out)           :: ncid
+    ! local
+    integer :: mpp_pio_openfile, stat
+    integer :: nmode
+    logical :: file_exists
+    integer :: nDimensions
+
+    !print *, "OPENING >>>>>>>>>>>>>>>> ", trim(file_name)
+
+    inquire(file=trim(file_name), exist=file_exists)
+
+    if (action_flag == MPP_WRONLY) then
+      nmode = pio_write
+    else if (action_flag == MPP_OVERWR) then
+      if (.not. file_exists) then
+        nmode = pio_write
+      else
+        nmode = pio_clobber
+      endif
+    else if (action_flag == MPP_RDONLY) then
+      nmode = pio_nowrite
+    else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+    endif
+
+    if (trim(pio_netcdf_format) == "64bit_offset" .or. trim(pio_netcdf_format) == "64BIT_OFFSET") then
+      nmode = ior(nmode, PIO_64BIT_OFFSET)
+    else if (trim(pio_netcdf_format) == "64bit_data" .or. trim(pio_netcdf_format) == "64BIT_DATA") then
+      nmode = ior(nmode, PIO_64BIT_DATA)
+    else
+      print *, trim(pio_netcdf_format)
+      call mpp_error(FATAL,'Cannot determine pio_netcdf_format')
+    endif
+
+    if (pio_file_is_open(file_desc)) then
+      mpp_pio_openfile = 0
+      return
+    endif
+
+    if (action_flag == MPP_WRONLY .or. action_flag == MPP_OVERWR ) then
+      stat = pio_createfile(pio_iosystem, file_desc, pio_iotype, trim(file_name), nmode)
+    else if (action_flag == MPP_RDONLY) then
+      stat = pio_openfile(pio_iosystem, file_desc, pio_iotype, trim(file_name), nmode)
+    else
+      print *, "NOT_IMPLEMENTED ", __FILE__, __LINE__
+      call mpp_error(FATAL,'TODO - NOT_IMPLEMENTED')
+    endif
+
+    ncid = file_desc%fh
+
+    mpp_pio_openfile = stat
+  end function mpp_pio_openfile
+
+  ! determine dimension layout index:
+  ! ( we need to determine the dimension layout, because we may need to treat, for instance,  two 3D fields
+  ! differently, e.g., when the third dimension of one field is z-coordinate  while the third dimension of
+  ! another field may be time.
+  integer function get_dlo(ndim, time_axis_index)
+    integer, intent(in) :: ndim
+    integer, intent(in) :: time_axis_index
+
+    if (ndim==2) then
+      get_dlo = 1
+    elseif (ndim==3 .and. time_axis_index==-1) then
+      get_dlo = 2
+    elseif (ndim==3 .and. time_axis_index/=-1) then
+      get_dlo = 3
+    elseif (ndim==4 .and. time_axis_index==-1) then
+      get_dlo = 4
+    elseif (ndim==4 .and. time_axis_index/=-1) then
+      get_dlo = 5
+    else
+      call mpp_error(FATAL,'get_dlo - Cannot determine dimension configuration')
+    endif
+
+    return
+  end function get_dlo
+
+  subroutine get_ioDesc_ptr(pos, ndim, dlen, basetype_nf, time_axis_index, ioDesc_ptr)
+    integer, intent(in) :: pos
+    integer, intent(in) :: ndim
+    integer, dimension(:), pointer :: dlen
+    integer, intent(in) :: basetype_nf
+    integer, intent(in) :: time_axis_index
+    type (IO_desc_t), pointer  :: ioDesc_ptr
+    !local
+    integer :: len3
+    integer :: len4
+    integer :: i, ilen3, ilen4
+    integer :: dlo ! dimension layout index
+
+    if (associated(ioDesc_ptr)) then
+      call mpp_error(FATAL,'ioDesc to be set already associated')
+    endif
+
+    dlo = get_dlo(ndim, time_axis_index)
+
+    len3=1; len4=1;
+    if (ndim>=3) len3 = dlen(3)
+    if (ndim>=4) len4 = dlen(4)
+
+    ! Determine the dimension length index for dimension3
+    ilen3 = 0
+    if (len3==1) then
+      ilen3 = 1
+    else if (len3>1) then
+      ! check if this size was entered before
+      do i=2, maxl3
+        if (lens3(i) == len3) ilen3 = i
+      enddo
+
+      ! ilen3 was not entered before. Enter it:
+      if (ilen3==0) then
+        if (.not. any(lens3(2:) == 0) ) then
+          call mpp_error(FATAL,'No available entry left in lens3. May need to increase maxl3')
+        endif
+        do i=2,maxl3
+          if (lens3(i) == 0 ) then
+            lens3(i) = len3
+            ilen3 = i
+            exit
+          endif
+        enddo
+      endif
+    else
+      call mpp_error(FATAL,'Invalid dimension length')
+    endif
+
+    ! Determine the dimension length index for dimension4
+    ilen4 = 0
+    if (len4==1) then
+      ilen4 = 1
+    else if (len4>1) then
+      ! check if this size was entered before
+      do i=2, maxl4
+        if (lens4(i) == len4) ilen4 = i
+      enddo
+
+      ! ilen4 was not entered before. Enter it:
+      if (ilen4==0) then
+        if (.not. any(lens4(2:) == 0) ) then
+          call mpp_error(FATAL,'No available entry left in lens4. May need to increase maxl4')
+        endif
+        do i=2,maxl4
+          if (lens4(i) == 0 ) then
+            lens4(i) = len4
+            ilen4 = i
+            exit
+          endif
+        enddo
+      endif
+    else
+      call mpp_error(FATAL,'Invalid dimension length')
+    endif
+
+    select case (basetype_nf)
+      case(NF_INT)
+        ioDesc_ptr => ioDesc_i(pos,dlo,ilen3,ilen4)%ptr
+      case(NF_REAL)
+        ioDesc_ptr => ioDesc_r(pos,dlo,ilen3,ilen4)%ptr
+      case(NF_DOUBLE)
+        ioDesc_ptr => ioDesc_d(pos,dlo,ilen3,ilen4)%ptr
+      case default
+        call mpp_error(FATAL,'get_ioDesc - Unknown kind')
+    end select
+
+  end subroutine get_ioDesc_ptr
+
+#endif
+end module mpp_pio_mod


### PR DESCRIPTION
This PR is a preliminary attempt to introduce PIO in FMS within CESM. In this early version, PIO is used for write operations only. For read operations, the standard netcdf is used. 

Note:
 - A new cppdef, `use_PIO`, is introduced to encapsulate changes containing PIO directives.
 
Brief description of changes in each file:
- `mpp/include/mpp_comm_mpi.inc` and `mpp/mpp.F90`:  (*modified*)
    - introduce an mpi_comm getter function to pass it to PIO.
- `mpp/include/mpp_io_connect.inc`: (*modified*)
    - set `write_on_this_pe` to `.true.` for all PEs when PIO is active.
    - Use PIO to open and close files to be written. TODO: do so for files to be read as well. 
- `mpp/include/mpp_io_misc.inc` (*modified*)
    - call `mpp_pio_init` within `mpp_io_init`.
    - call PIO_closefile and PIO_syncfile as needed.
- `mpp/include/mpp_pio_write.inc` (*new file*)
    - this file mimics`mpp_io_write.inc` and implements various write functions. Instead of standard netcdf, it calls PIO routines. Some of the subroutines in this file is not called by MOM6, and so they are skipped for now. (A NOT_IMPEMENTED error gets thrown if they ever get called.)
 - `mpp/include/mpp_write_2Ddecomp.h` (*modified*)
     - PIO versions of varios standard netcdf routines are introduced. Changes are encapsulated by `use_PIO` ifdefs.
- `mpp/mpp_io.F90` (*modified*)
    - import all necessary PIO routines.
    - add ioDesc and fileDesc to `fieldtype` and `filetype` respectively.
    - if `use_PIO`, include `mpp_pio_write` instead of the original `mpp_io_write`.
- `mpp/mpp_io.F90` (*new module*)
   - This is a new module that implements some PIO-specific tasks including reading in the `mpp_pio_nml` namelist from `input.nml`, the initialization of PIO,  decomposition, etc...
 
In addition to this PR, the following FMS_interface and MOM_interface branches must be used. All other components/libraries should be the same as cesm2_3_beta13.

#### FMS_interface: add_PIO_to_FMS_interface
https://github.com/ESCOMP/FMS_interface/tree/add_PIO_to_FMS_interface

#### MOM_interface: add_PIO_to_FMS
https://github.com/ESCOMP/MOM_interface/tree/add_PIO_to_FMS

Here is my CESM sandbox on cheyenne: /glade/work/altuntas/cesm.sandboxes/cesm2_3_beta13.pio

### Testing

@jedwards4b This initial version doesn't appear to improve the performance at all. I ran 5-day GMOM_JRA runs where I switched all the monthly files to daily. In the first case (without PIO), I got 5.81 simulated_years/day. In the second case where PIO is enabled, I still got 5.81 simulated_years/day. PIO namelist is set as follows:

&mpp_pio_nml
    pio_netcdf_format = 64bit_offset
    pio_rearranger = 2
    pio_root = 1
    pio_stride = 36
    pio_numiotasks = 24
    pio_typename = pnetcdf
/

Caseroots:
/glade/scratch/altuntas/g.e23.GMOM_JRA.TL319_t061.no_pio.001
/glade/scratch/altuntas/g.e23.GMOM_JRA.TL319_t061.pio_on.001
